### PR TITLE
plugins: workaround non-alphanumeric char issue

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -52,20 +52,26 @@ module.exports = {
                         `Please place a space after the first colon character in your commit message title`
                     ];
                 },
-                'subject-lowercase': ({subject}: {subject:any}) => {
+
+                // NOTE: we use 'header' instead of 'subject' as a workaround to this bug: https://github.com/conventional-changelog/commitlint/issues/3404
+                'subject-lowercase': ({header}: {header:any}) => {
                     // to convert from 'any' type
-                    let subjectStr = String(subject);
+                    let headerStr = String(header);
 
                     let offence = false;
-                    if (subjectStr != null && subjectStr.length > 1) {
-                        let firstIsUpperCase = subjectStr[0].toUpperCase() == subjectStr[0];
-                        let firstIsLowerCase = subjectStr[0].toLowerCase() == subjectStr[0];
-                        let secondIsUpperCase = subjectStr[1].toUpperCase() == subjectStr[1];
-                        let secondIsLowerCase = subjectStr[1].toLowerCase() == subjectStr[1];
+                    let colonFirstIndex = headerStr.indexOf(":");
+                    if ((colonFirstIndex > 0) && (headerStr.length > colonFirstIndex)) {
+                        let subject = headerStr.substring(colonFirstIndex + 1).trim();
+                        if (subject != null && subject.length > 1) {
+                            let firstIsUpperCase = subject[0].toUpperCase() == subject[0];
+                            let firstIsLowerCase = subject[0].toLowerCase() == subject[0];
+                            let secondIsUpperCase = subject[1].toUpperCase() == subject[1];
+                            let secondIsLowerCase = subject[1].toLowerCase() == subject[1];
 
-                        offence = firstIsUpperCase && (!firstIsLowerCase)
-                            // to whitelist acronyms
-                            && (!secondIsUpperCase) && secondIsLowerCase;
+                            offence = firstIsUpperCase && (!firstIsLowerCase)
+                                // to whitelist acronyms
+                                && (!secondIsUpperCase) && secondIsLowerCase;
+                        }
                     }
 
                     return [

--- a/commitlintplugins.test.ts
+++ b/commitlintplugins.test.ts
@@ -45,6 +45,27 @@ test('subject-lowercase3', () => {
 test('subject-lowercase4', () => {
     let commitMsgWithNonAlphanumericAfterColon = "foo: 3 tests added"
     let subjectLowerCase4 = spawnSync('npx', ['commitlint', '--verbose'], { input: commitMsgWithNonAlphanumericAfterColon });
-    //console.log("=============>" + subjectLowerCase4.stdout);
     expect(subjectLowerCase4.status).toBe(0);
+});
+
+
+test('subject-lowercase5', () => {
+    let commitMsgWithRareCharInArea1 = "foo.bar: Baz"
+    let subjectLowerCase5 = spawnSync('npx', ['commitlint', '--verbose'], { input: commitMsgWithRareCharInArea1 });
+    expect(subjectLowerCase5.status).not.toBe(0);
+});
+
+
+test('subject-lowercase6', () => {
+    let commitMsgWithRareCharInArea2 = "foo-bar: Baz"
+    let subjectLowerCase6 = spawnSync('npx', ['commitlint', '--verbose'], { input: commitMsgWithRareCharInArea2 });
+    expect(subjectLowerCase6.status).not.toBe(0);
+});
+
+
+test('subject-lowercase7', () => {
+    let commitMsgWithRareCharInArea3 = "foo,bar: Baz"
+    let subjectLowerCase7 = spawnSync('npx', ['commitlint', '--verbose'], { input: commitMsgWithRareCharInArea3 });
+    //console.log("=============>" + subjectLowerCase7.stdout);
+    expect(subjectLowerCase7.status).not.toBe(0);
 });


### PR DESCRIPTION
Due to a bug on how commitlint treats areas/scopes (what they call "type") with some alphanumeric chars (such as dots, dashes and commas), we need to bind to header instead to fix the unit tests (which are in previous commit).