### PR TITLE
Rule for body max line length

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,10 +1,10 @@
 // to convert from 'any' type
-function convertHeaderToString(header: any): string {
-    if (header === null || header === undefined) {
+function convertAnyToString(potentialString: any, paramName: string): string {
+    if (potentialString === null || potentialString === undefined) {
         // otherwise, String(null) might give us the stupid string "null"
-        throw new Error('Unexpected header===null or header===undefined happened');
+        throw new Error('Unexpected ' + paramName + '===null or ' + paramName + '===undefined happened');
     }
-    return String(header);
+    return String(potentialString);
 }
 
 enum RuleStatus {
@@ -17,9 +17,7 @@ module.exports = {
     parserPreset: 'conventional-changelog-conventionalcommits',
     rules: {
         'body-leading-blank': [RuleStatus.Warning, 'always'],
-
-        // TODO: are URLs whitelisted?
-        'body-max-line-length': [RuleStatus.Error, 'always', 64],
+        'body-soft-max-line-length': [RuleStatus.Error, 'always', 64],
         'footer-leading-blank': [RuleStatus.Warning, 'always'],
         'footer-max-line-length': [RuleStatus.Error, 'always', 150],
         'header-max-length': [RuleStatus.Error, 'always', 50],
@@ -52,7 +50,7 @@ module.exports = {
         {
             rules: {
                 'type-space-after-colon': ({header}: {header:any}) => {
-                    let headerStr = convertHeaderToString(header);
+                    let headerStr = convertAnyToString(header, "header");
 
                     let colonFirstIndex = headerStr.indexOf(":");
 
@@ -71,7 +69,7 @@ module.exports = {
 
                 // NOTE: we use 'header' instead of 'subject' as a workaround to this bug: https://github.com/conventional-changelog/commitlint/issues/3404
                 'subject-lowercase': ({header}: {header:any}) => {
-                    let headerStr = convertHeaderToString(header);
+                    let headerStr = convertAnyToString(header, "header");
 
                     let offence = false;
                     let colonFirstIndex = headerStr.indexOf(":");
@@ -94,8 +92,9 @@ module.exports = {
                         `Please use lowercase as the first letter for your subject, i.e. the text after your area/scope`
                     ];
                 },
+
                 'type-space-after-comma': ({header}: {header:any}) => {
-                    let headerStr = convertHeaderToString(header);
+                    let headerStr = convertAnyToString(header, "header");
 
                     let offence = false;
                     let colonIndex = headerStr.indexOf(":");
@@ -114,6 +113,27 @@ module.exports = {
                     return [
                         !offence,
                         `No need to use space after comma in the area/scope (so that commit title can be shorter)`
+                    ];
+                },
+
+                'body-soft-max-line-length': ({body}: {body:any}) => {
+                    let offence = false;
+
+                    // does msg have a body?
+                    if (body !== null) {
+                        let bodyStr = convertAnyToString(body, "body");
+
+                        let lines = bodyStr.split(/\r?\n/);
+                        for (let line of lines) {
+                            if (line.length > 64 && line.indexOf(" ") >= 0) {
+                                offence = true;
+                            }
+                        }
+                    }
+
+                    return [
+                        !offence,
+                        `Please do not exceed 64 characters in the lines of the commit message's body`
                     ];
                 }
             }

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -17,8 +17,9 @@ module.exports = {
     parserPreset: 'conventional-changelog-conventionalcommits',
     rules: {
         'body-leading-blank': [RuleStatus.Warning, 'always'],
-// disable this one until we find a way for URLs to be allowed:
-//      'body-max-line-length': [RuleStatus.Error, 'always', 64],
+
+        // TODO: are URLs whitelisted?
+        'body-max-line-length': [RuleStatus.Error, 'always', 64],
         'footer-leading-blank': [RuleStatus.Warning, 'always'],
         'footer-max-line-length': [RuleStatus.Error, 'always', 150],
         'header-max-length': [RuleStatus.Error, 'always', 50],

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -13,11 +13,13 @@ enum RuleStatus {
     Error = 2,
 }
 
+let bodyMaxLineLength = 64;
+
 module.exports = {
     parserPreset: 'conventional-changelog-conventionalcommits',
     rules: {
         'body-leading-blank': [RuleStatus.Warning, 'always'],
-        'body-soft-max-line-length': [RuleStatus.Error, 'always', 64],
+        'body-soft-max-line-length': [RuleStatus.Error, 'always'],
         'footer-leading-blank': [RuleStatus.Warning, 'always'],
         'footer-max-line-length': [RuleStatus.Error, 'always', 150],
         'header-max-length': [RuleStatus.Error, 'always', 50],
@@ -125,7 +127,7 @@ module.exports = {
 
                         let lines = bodyStr.split(/\r?\n/);
                         for (let line of lines) {
-                            if (line.length > 64) {
+                            if (line.length > bodyMaxLineLength) {
 
                                 // it's a URL
                                 let containsASpace = line.indexOf(" ") >= 0;
@@ -137,6 +139,7 @@ module.exports = {
 
                                 if (containsASpace && (!startsWithRef) && (!startWithFixesSentence)) {
                                     offence = true;
+                                    break;
                                 }
                             }
                         }

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -133,7 +133,9 @@ module.exports = {
                                 // it's a footer reference, i.e. [1] someUrl://foo/bar/baz
                                 let startsWithRef = (line[0] == "[" && line.indexOf("] ") > 0);
 
-                                if (containsASpace && (!startsWithRef)) {
+                                let startWithFixesSentence = (line.indexOf("Fixes ") == 0);
+
+                                if (containsASpace && (!startsWithRef) && (!startWithFixesSentence)) {
                                     offence = true;
                                 }
                             }

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -125,8 +125,17 @@ module.exports = {
 
                         let lines = bodyStr.split(/\r?\n/);
                         for (let line of lines) {
-                            if (line.length > 64 && line.indexOf(" ") >= 0) {
-                                offence = true;
+                            if (line.length > 64) {
+
+                                // it's a URL
+                                let containsASpace = line.indexOf(" ") >= 0;
+
+                                // it's a footer reference, i.e. [1] someUrl://foo/bar/baz
+                                let startsWithRef = (line[0] == "[" && line.indexOf("] ") > 0);
+
+                                if (containsASpace && (!startsWithRef)) {
+                                    offence = true;
+                                }
                             }
                         }
                     }

--- a/commitlintplugins.test.ts
+++ b/commitlintplugins.test.ts
@@ -98,3 +98,14 @@ test('body-max-line-length1', () => {
     expect(bodyMaxLineLength1.status).toBe(0);
 });
 
+
+test('body-max-line-length2', () => {
+    let tenChars = "1234567890";
+    let sixtyChars = tenChars + tenChars + tenChars + tenChars + tenChars + tenChars;
+    let commitMsgWithOnlySixtyFiveCharsInBody =
+        "foo,bar: bla bla blah" + "\n\n" + sixtyChars + "12345";
+    let bodyMaxLineLength2 = runCommitLintOnMsg(commitMsgWithOnlySixtyFiveCharsInBody);
+    //console.log("=============>" + bodyMaxLineLength2.stdout);
+    expect(bodyMaxLineLength2.status).not.toBe(0);
+});
+

--- a/commitlintplugins.test.ts
+++ b/commitlintplugins.test.ts
@@ -89,23 +89,34 @@ test('type-space-after-comma2', () => {
 
 
 test('body-max-line-length1', () => {
-    let tenChars = "1234567890";
+    let tenChars = "1234 67890";
     let sixtyChars = tenChars + tenChars + tenChars + tenChars + tenChars + tenChars;
     let commitMsgWithOnlySixtyFourCharsInBody =
-        "foo,bar: bla bla blah" + "\n\n" + sixtyChars + "1234";
+        "foo: this is only a title" + "\n\n" + sixtyChars + "1234";
     let bodyMaxLineLength1 = runCommitLintOnMsg(commitMsgWithOnlySixtyFourCharsInBody);
-    //console.log("=============>" + bodyMaxLineLength1.stdout);
     expect(bodyMaxLineLength1.status).toBe(0);
 });
 
 
 test('body-max-line-length2', () => {
-    let tenChars = "1234567890";
+    let tenChars = "1234 67890";
     let sixtyChars = tenChars + tenChars + tenChars + tenChars + tenChars + tenChars;
     let commitMsgWithOnlySixtyFiveCharsInBody =
-        "foo,bar: bla bla blah" + "\n\n" + sixtyChars + "12345";
+        "foo: this is only a title" + "\n\n" + sixtyChars + "12345";
     let bodyMaxLineLength2 = runCommitLintOnMsg(commitMsgWithOnlySixtyFiveCharsInBody);
-    //console.log("=============>" + bodyMaxLineLength2.stdout);
     expect(bodyMaxLineLength2.status).not.toBe(0);
+});
+
+
+test('body-max-line-length3', () => {
+    let tenDigits = "1234567890";
+    let seventyChars = tenDigits + tenDigits + tenDigits + tenDigits + tenDigits + tenDigits + tenDigits;
+    let commitMsgWithUrlThatExceedsBodyMaxLineLength =
+        "foo: this is only a title" + "\n\n" + "someUrl://" + seventyChars;
+    let bodyMaxLineLength3 = runCommitLintOnMsg(commitMsgWithUrlThatExceedsBodyMaxLineLength);
+    //console.log("=============>" + bodyMaxLineLength3.stdout);
+
+    // because URLs can bypass the limit
+    expect(bodyMaxLineLength3.status).toBe(0);
 });
 

--- a/commitlintplugins.test.ts
+++ b/commitlintplugins.test.ts
@@ -84,6 +84,17 @@ test('type-space-after-comma1', () => {
 test('type-space-after-comma2', () => {
     let commitMsgWithNoSpaceAfterCommaInType = "foo,bar: bla bla blah";
     let typeSpaceAfterComma2 = runCommitLintOnMsg(commitMsgWithNoSpaceAfterCommaInType);
-    //console.log("=============>" + typeSpaceAfterComma2.stdout);
     expect(typeSpaceAfterComma2.status).toBe(0);
 });
+
+
+test('body-max-line-length1', () => {
+    let tenChars = "1234567890";
+    let sixtyChars = tenChars + tenChars + tenChars + tenChars + tenChars + tenChars;
+    let commitMsgWithOnlySixtyFourCharsInBody =
+        "foo,bar: bla bla blah" + "\n\n" + sixtyChars + "1234";
+    let bodyMaxLineLength1 = runCommitLintOnMsg(commitMsgWithOnlySixtyFourCharsInBody);
+    //console.log("=============>" + bodyMaxLineLength1.stdout);
+    expect(bodyMaxLineLength1.status).toBe(0);
+});
+

--- a/commitlintplugins.test.ts
+++ b/commitlintplugins.test.ts
@@ -126,9 +126,21 @@ test('body-max-line-length4', () => {
     let commitMsgWithUrlThatExceedsBodyMaxLineLength =
         "foo: this is only a title" + "\n\n" + "bla blah[1] bla\n\n[1] someUrl://" + seventyChars;
     let bodyMaxLineLength4 = runCommitLintOnMsg(commitMsgWithUrlThatExceedsBodyMaxLineLength);
-    //console.log("=============>" + bodyMaxLineLength4.stdout);
 
     // because URLs in footer can bypass the limit
     expect(bodyMaxLineLength4.status).toBe(0);
+});
+
+
+test('body-max-line-length5', () => {
+    let tenDigits = "1234567890";
+    let seventyChars = tenDigits + tenDigits + tenDigits + tenDigits + tenDigits + tenDigits + tenDigits;
+    let commitMsgWithUrlThatExceedsBodyMaxLineLength =
+        "foo: this is only a title" + "\n\n" + "Fixes someUrl://" + seventyChars;
+    let bodyMaxLineLength5 = runCommitLintOnMsg(commitMsgWithUrlThatExceedsBodyMaxLineLength);
+    //console.log("=============>" + bodyMaxLineLength5.stdout);
+
+    // because URLs in "Fixes <URL>" sentence can bypass the limit
+    expect(bodyMaxLineLength5.status).toBe(0);
 });
 

--- a/commitlintplugins.test.ts
+++ b/commitlintplugins.test.ts
@@ -114,9 +114,21 @@ test('body-max-line-length3', () => {
     let commitMsgWithUrlThatExceedsBodyMaxLineLength =
         "foo: this is only a title" + "\n\n" + "someUrl://" + seventyChars;
     let bodyMaxLineLength3 = runCommitLintOnMsg(commitMsgWithUrlThatExceedsBodyMaxLineLength);
-    //console.log("=============>" + bodyMaxLineLength3.stdout);
 
     // because URLs can bypass the limit
     expect(bodyMaxLineLength3.status).toBe(0);
+});
+
+
+test('body-max-line-length4', () => {
+    let tenDigits = "1234567890";
+    let seventyChars = tenDigits + tenDigits + tenDigits + tenDigits + tenDigits + tenDigits + tenDigits;
+    let commitMsgWithUrlThatExceedsBodyMaxLineLength =
+        "foo: this is only a title" + "\n\n" + "bla blah[1] bla\n\n[1] someUrl://" + seventyChars;
+    let bodyMaxLineLength4 = runCommitLintOnMsg(commitMsgWithUrlThatExceedsBodyMaxLineLength);
+    //console.log("=============>" + bodyMaxLineLength4.stdout);
+
+    // because URLs in footer can bypass the limit
+    expect(bodyMaxLineLength4.status).toBe(0);
 });
 


### PR DESCRIPTION
Existing body-max-line-length rule from commitlint doesn't whitelist URLs so we created a new custom one.