### PR TITLE
Add rule to check if a footer line is in body

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -104,6 +104,7 @@ module.exports = {
         'empty-wip': [RuleStatus.Error, 'always'],
         'footer-leading-blank': [RuleStatus.Warning, 'always'],
         'footer-max-line-length': [RuleStatus.Error, 'always', 150],
+        'footer-notes-misplacement': [RuleStatus.Error, 'always'],
         'header-max-length-with-suggestions': [RuleStatus.Error, 'always', headerMaxLineLength],
         'subject-full-stop': [RuleStatus.Error, 'never', '.'],
         'type-empty': [RuleStatus.Warning, 'never'],
@@ -210,7 +211,35 @@ module.exports = {
                         message
                     ];
                 },
-                
+
+                'footer-notes-misplacement': ({body}: {body:any}) => {
+                    let offence = false;
+
+                    if (body !== null) {
+                        let bodyStr = convertAnyToString(body, "body");
+
+                        let seenBody = false;
+                        let seenFooter = false;
+                        let lines = bodyStr.split(/\r?\n/);
+                        for (let line of lines) {
+                            if (line.length === 0){
+                                continue;
+                            }
+                            seenBody = seenBody || !isFooterNote(line);
+                            seenFooter = seenFooter || isFooterNote(line);
+                            if (seenFooter && !isFooterNote(line)) {
+                                offence = true;
+                                break;
+                            }
+                            
+                        }
+                    }
+                    return [
+                        !offence,
+                        `Footer messages must be placed after body paragraphs, please move any message that starts with a "[]" or "Fixes" to the end of the commmit message.`
+                    ]
+                },
+
                 'prefer-slash-over-backslash': ({header}: {header:any}) => {
                     let headerStr = convertAnyToString(header, "header");
 

--- a/commitlintplugins.test.ts
+++ b/commitlintplugins.test.ts
@@ -181,6 +181,37 @@ test('empty-wip-3', () => {
 });
 
 
+test('footer-notes-misplacement-1', () => {
+    let commitMsgWithRightFooter = "foo: this is only a title" 
+        + "\n\n"+ "Bla bla blah[1]." 
+        + "\n\n" + "Fixes https://some/issue" 
+        + "\n\n" + "[1] http://foo.bar/baz";
+    let footerNotesMisplacement1 = runCommitLintOnMsg(commitMsgWithRightFooter);
+    expect(footerNotesMisplacement1.status).toBe(0);
+})
+
+
+test('footer-notes-misplacement-2', () => {
+    let commitMsgWithWrongFooter = "foo: this is only a title" 
+        + "\n\n" + "Fixes https://some/issue" 
+        + "\n\n"+ "Bla bla blah[1]." 
+        + "\n\n" + "[1] http://foo.bar/baz";
+    let footerNotesMisplacement2 = runCommitLintOnMsg(commitMsgWithWrongFooter);
+    expect(footerNotesMisplacement2.status).not.toBe(0);
+})
+
+
+test('footer-notes-misplacement-3', () => {
+    let commitMsgWithWrongFooter = "foo: this is only a title" 
+        + "\n\n"+ "Bla bla blah[1]." 
+        + "\n\n" + "[1] http://foo.bar/baz"
+        + "\n\n" + "Some other bla bla blah."
+        + "\n\n" + "Fixes https://some/issue";
+    let footerNotesMisplacement3 = runCommitLintOnMsg(commitMsgWithWrongFooter);
+    expect(footerNotesMisplacement3.status).not.toBe(0);
+})
+
+
 test('prefer-slash-over-backslash1', () => {
     let commitMsgWithBackslash = "foo\\bar: bla bla bla";
     let preferSlashOverBackslash1 = runCommitLintOnMsg(commitMsgWithBackslash);


### PR DESCRIPTION
Messages that start with "Fixes" or "[]" should be in the footer this newly added rule will check this behavior and will raise errors if it's not correctly addressed.