### PR TITLE
Rule to check every reference is used in body and footer

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -262,6 +262,7 @@ module.exports = {
         'footer-leading-blank': [RuleStatus.Warning, 'always'],
         'footer-max-line-length': [RuleStatus.Error, 'always', 150],
         'footer-notes-misplacement': [RuleStatus.Error, 'always'],
+        'footer-references-existence': [RuleStatus.Error, 'always'],
         'header-max-length-with-suggestions': [RuleStatus.Error, 'always', headerMaxLineLength],
         'subject-full-stop': [RuleStatus.Error, 'never', '.'],
         'type-empty': [RuleStatus.Warning, 'never'],
@@ -394,6 +395,47 @@ module.exports = {
                     return [
                         !offence,
                         `Footer messages must be placed after body paragraphs, please move any message that starts with a "[]" or "Fixes" to the end of the commmit message.`
+                    ]
+                },
+
+                'footer-references-existence': ({body}: {body:any}) => {
+                    let offence = false;
+
+                    if (body !== null) {
+                        let bodyStr = convertAnyToString(body, "body");
+                        let lines = bodyStr.split(/\r?\n/);
+                        let bodyReferences = new Set();
+                        let references = new Set();
+                        for (let line of lines) {
+                            let matches = line.match(/(?<=\[)([0-9]+)(?=\])/g);
+                            if (matches === null) {
+                                continue;
+                            }
+                            for (let match of matches){
+                                if (isFooterReference(line)) {
+                                    references.add(match);
+                                }
+                                else {
+                                    bodyReferences.add(match);
+                                }
+                            }
+                        }
+                        for (let ref of bodyReferences) {
+                            if (!references.has(ref)) {
+                                offence = true;
+                                break;
+                            }
+                        }
+                        for (let ref of references) {
+                            if (!bodyReferences.has(ref)) {
+                                offence = true;
+                                break;
+                            }
+                        }
+                    }
+                    return [
+                        !offence,
+                        "All references in the body must be mentioned in the footer, and vice versa."
                     ]
                 },
 

--- a/commitlintplugins.test.ts
+++ b/commitlintplugins.test.ts
@@ -212,6 +212,34 @@ test('footer-notes-misplacement-3', () => {
 })
 
 
+test('footer-references-existence1', () => {
+    let commmitMsgwithCorrectFooter = "foo: this is only a title"
+        + "\n\n"+ "Bla bla blah[1]."
+        + "\n\n" + "[1] http://foo.bar/baz"
+    let footerReferenceExistence1 = runCommitLintOnMsg(commmitMsgwithCorrectFooter);
+    expect(footerReferenceExistence1.status).toBe(0);
+})
+
+
+test('footer-references-existence2', () => {
+    let commmitMsgwithWrongFooter = "foo: this is only a title"
+        + "\n\n"+ "Bla bla blah."
+        + "\n\n" + "[1] http://foo.bar/baz"
+    let footerReferenceExistence2 = runCommitLintOnMsg(commmitMsgwithWrongFooter);
+    expect(footerReferenceExistence2.status).not.toBe(0);
+})
+
+
+test('footer-references-existence3', () => {
+    let commmitMsgwithWrongFooter = "foo: this is only a title"
+        + "\n\n"+ "Bla bla blah[1], and after that [2], then [3]."
+        + "\n\n" + "[1] http://foo.bar/baz"
+        + "\n\n" + "[2] http://foo.bar/baz"
+    let footerReferenceExistence3 = runCommitLintOnMsg(commmitMsgwithWrongFooter);
+    expect(footerReferenceExistence3.status).not.toBe(0);
+})
+
+
 test('prefer-slash-over-backslash1', () => {
     let commitMsgWithBackslash = "foo\\bar: bla bla bla";
     let preferSlashOverBackslash1 = runCommitLintOnMsg(commitMsgWithBackslash);


### PR DESCRIPTION
Prohibit contributors from defining a reference and not putting it in the footer or putting a reference in the footer which is not defined in the body.