### PR TITLE
Detect inconsistent (e.g. pulumi) versions in GitHubCI and (e.g. nuget pkgs versions) in fsx scripts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -182,6 +182,8 @@ jobs:
       - name: Check if gitPush1by1 was used
         if: github.event_name == 'pull_request'
         run: dotnet fsi scripts/detectNotUsingGitPush1by1.fsx
+      - name: Check there are no inconsistent versions GitHubCI files
+        run: dotnet fsi scripts/inconsistentVersionsInGitHubCI.fsx
       - name: Install prettier
         run: npm install prettier@2.8.3
       - name: Change file permissions

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -184,6 +184,8 @@ jobs:
         run: dotnet fsi scripts/detectNotUsingGitPush1by1.fsx
       - name: Check there are no inconsistent versions GitHubCI files
         run: dotnet fsi scripts/inconsistentVersionsInGitHubCI.fsx
+      - name: Check there are no inconsistent versions in nuget package references of F# scripts
+        run: dotnet fsi scripts/inconsistentVersionsInFSharpScripts.fsx
       - name: Install prettier
         run: npm install prettier@2.8.3
       - name: Change file permissions

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ TestResult.xml
 TestResults.xml
 
 # Visual Studio cache files
+.vs/
 # files ending in .cache can be ignored
 *.[Cc]ache
 # but keep track of directories ending in .cache

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -15,6 +15,9 @@ This is a repository that contains several useful things that other `nblockchain
         * [Use of asterisk (*) in `PackageReference` items of .NET projects](scripts/unpinnedDotnetPackageVersions.fsx).
         * [Missing the version number in `#r "nuget: ` refs of F# scripts](scripts/unpinnedNugetPackageReferenceVersions.fsx).
         * [Missing the `--version` flag in `dotnet tool install foo` invocations](scripts/unpinnedDotnetToolInstallVersions.fsx).
+    * Use of inconsistent versions:
+        * [Use of inconsistent version numbers in `uses:` and `with:` GitHubCI tags](scripts/inconsistentVersionsInGitHubCI.fsx).
+        * [Use of inconsistent version numbers in `#r "nuget: ` refs of F# scripts](scripts/inconsistentVersionsInFSharpScripts.fsx).
 
 All in all, this is mainly documentation, and some tooling to detect bad practices.
 

--- a/scripts/inconsistentVersionsInFSharpScripts.fsx
+++ b/scripts/inconsistentVersionsInFSharpScripts.fsx
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S dotnet fsi
+
+open System.IO
+
+#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/Helpers.fs"
+
+let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+
+let inconsistentVersionsInFsharpScripts =
+    Helpers.GetFiles rootDir "*.fsx"
+    |> FileConventions.DetectInconsistentVersionsInNugetRefsInFSharpScripts
+
+if inconsistentVersionsInFsharpScripts then
+    failwith
+        "You shouldn't use inconsistent versions in nuget package references of F# scripts."

--- a/scripts/inconsistentVersionsInGitHubCI.fsx
+++ b/scripts/inconsistentVersionsInGitHubCI.fsx
@@ -1,0 +1,15 @@
+#!/usr/bin/env -S dotnet fsi
+
+open System.IO
+
+#load "../src/FileConventions/Library.fs"
+
+let githubWorkflowsDir =
+    Path.Combine(__SOURCE_DIRECTORY__, "../.github/workflows") |> DirectoryInfo
+
+let inconsistentVersionsInGitHubCI =
+    FileConventions.DetectInconsistentVersionsInGitHubCI githubWorkflowsDir
+
+if inconsistentVersionsInGitHubCI then
+    failwith
+        "You shouldn't use inconsistent versions in `uses: foo@bar` or `with: foo-version: bar` statements in GitHubCI files."

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithSamePulumiVersion.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithSamePulumiVersion.yml
@@ -1,0 +1,25 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"
+  jobB:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithSameSetupPulumiVersion.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithSameSetupPulumiVersion.yml
@@ -1,0 +1,25 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"
+  jobB:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithSetupPulumiVersionV2.0.0.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithSetupPulumiVersionV2.0.0.yml
@@ -1,0 +1,15 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithSetupPulumiVersionV2.0.1.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithSetupPulumiVersionV2.0.1.yml
@@ -1,0 +1,15 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.1
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithoutSameCheckoutVersion.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithoutSameCheckoutVersion.yml
@@ -1,0 +1,17 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Print "Hello World!"
+        run: echo "Hello World!"
+  jobB:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithoutSameNodeVersion.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithoutSameNodeVersion.yml
@@ -1,0 +1,23 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "14"
+      - name: Print "Hello World!"
+        run: echo "Hello World!"
+  jobB:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithoutSamePulumiVersion.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithoutSamePulumiVersion.yml
@@ -1,0 +1,25 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"
+  jobB:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: 3.41.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithoutSameSetupPulumiVersion.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithoutSameSetupPulumiVersion.yml
@@ -1,0 +1,25 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"
+  jobB:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.1
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyFsharpScriptWithFsdkVersion0.6.0.fsx
+++ b/src/FileConventions.Test/DummyFiles/DummyFsharpScriptWithFsdkVersion0.6.0.fsx
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S dotnet fsi
+
+open System
+open System.IO
+
+#r "nuget: Fsdk, Version=0.6.0"
+
+printfn "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyFsharpScriptWithFsdkVersion0.6.1.fsx
+++ b/src/FileConventions.Test/DummyFiles/DummyFsharpScriptWithFsdkVersion0.6.1.fsx
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S dotnet fsi
+
+open System
+open System.IO
+
+#r "nuget: Fsdk, Version=0.6.1"
+
+printfn "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyScripts/DummyFsharpScriptWithFsdkVersion0.6.0.fsx
+++ b/src/FileConventions.Test/DummyFiles/DummyScripts/DummyFsharpScriptWithFsdkVersion0.6.0.fsx
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S dotnet fsi
+
+open System
+open System.IO
+
+#r "nuget: Fsdk, Version=0.6.0"
+
+printfn "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyScripts/DummyFsharpScriptWithFsdkVersion0.6.1.fsx
+++ b/src/FileConventions.Test/DummyFiles/DummyScripts/DummyFsharpScriptWithFsdkVersion0.6.1.fsx
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S dotnet fsi
+
+open System
+open System.IO
+
+#r "nuget: Fsdk, Version=0.6.1"
+
+printfn "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyWorkflows/DummyCIWithSetupPulumiVersionV2.0.0.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyWorkflows/DummyCIWithSetupPulumiVersionV2.0.0.yml
@@ -1,0 +1,15 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyWorkflows/DummyCIWithSetupPulumiVersionV2.0.1.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyWorkflows/DummyCIWithSetupPulumiVersionV2.0.1.yml
@@ -1,0 +1,15 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.1
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -493,3 +493,30 @@ let DetectInconsistentVersionsInGitHubCI1() =
         )
 
     Assert.That(DetectInconsistentVersionsInGitHubCI fileInfo, Is.EqualTo true)
+
+
+[<Test>]
+let DetectInconsistentVersionsInNugetRefsInFSharpScripts1() =
+    let fileInfos =
+        (seq {
+
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyFsharpScriptWithFsdkVersion0.6.0.fsx"
+                )
+            )
+
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyFsharpScriptWithFsdkVersion0.6.1.fsx"
+                )
+            )
+
+        })
+
+    Assert.That(
+        DetectInconsistentVersionsInNugetRefsInFSharpScripts fileInfos,
+        Is.EqualTo true
+    )

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -353,10 +353,12 @@ let WrapTextTest4() =
 
 let DetectInconsistentVersionsInGitHubCIWorkflow1() =
     let fileInfo =
-        (FileInfo(
-            Path.Combine(
-                dummyFilesDirectory.FullName,
-                "DummyCIWithSamePulumiVersion.yml"
+        (Seq.singleton(
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyCIWithSamePulumiVersion.yml"
+                )
             )
         ))
 
@@ -369,10 +371,12 @@ let DetectInconsistentVersionsInGitHubCIWorkflow1() =
 [<Test>]
 let DetectInconsistentVersionsInGitHubCIWorkflow2() =
     let fileInfo =
-        (FileInfo(
-            Path.Combine(
-                dummyFilesDirectory.FullName,
-                "DummyCIWithoutSamePulumiVersion.yml"
+        (Seq.singleton(
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyCIWithoutSamePulumiVersion.yml"
+                )
             )
         ))
 
@@ -385,10 +389,12 @@ let DetectInconsistentVersionsInGitHubCIWorkflow2() =
 [<Test>]
 let DetectInconsistentVersionsInGitHubCIWorkflow3() =
     let fileInfo =
-        (FileInfo(
-            Path.Combine(
-                dummyFilesDirectory.FullName,
-                "DummyCIWithoutSameSetupPulumiVersion.yml"
+        (Seq.singleton(
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyCIWithoutSameSetupPulumiVersion.yml"
+                )
             )
         ))
 
@@ -401,14 +407,43 @@ let DetectInconsistentVersionsInGitHubCIWorkflow3() =
 [<Test>]
 let DetectInconsistentVersionsInGitHubCIWorkflow4() =
     let fileInfo =
-        (FileInfo(
-            Path.Combine(
-                dummyFilesDirectory.FullName,
-                "DummyCIWithSameSetupPulumiVersion.yml"
+        (Seq.singleton(
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyCIWithSameSetupPulumiVersion.yml"
+                )
             )
         ))
 
     Assert.That(
         DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
         Is.EqualTo false
+    )
+
+
+[<Test>]
+let DetectInconsistentVersionsInGitHubCIWorkflow5() =
+    let fileInfo =
+        (seq {
+
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyCIWithSetupPulumiVersionV2.0.0.yml"
+                )
+            )
+
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyCIWithSetupPulumiVersionV2.0.1.yml"
+                )
+            )
+
+        })
+
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        Is.EqualTo true
     )

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -520,3 +520,15 @@ let DetectInconsistentVersionsInNugetRefsInFSharpScripts1() =
         DetectInconsistentVersionsInNugetRefsInFSharpScripts fileInfos,
         Is.EqualTo true
     )
+
+[<Test>]
+let DetectInconsistentVersionsInFSharpScripts1() =
+    let fileInfo =
+        DirectoryInfo(
+            Path.Combine(dummyFilesDirectory.FullName, "DummyScripts")
+        )
+
+    Assert.That(
+        DetectInconsistentVersionsInFSharpScripts fileInfo,
+        Is.EqualTo true
+    )

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -450,6 +450,24 @@ let DetectInconsistentVersionsInGitHubCIWorkflow5() =
 
 
 [<Test>]
+let DetectInconsistentVersionsInGitHubCIWorkflow6() =
+    let fileInfo =
+        (Seq.singleton(
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyCIWithoutSameCheckoutVersion.yml"
+                )
+            )
+        ))
+
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        Is.EqualTo true
+    )
+
+
+[<Test>]
 let DetectInconsistentVersionsInGitHubCI1() =
     let fileInfo =
         DirectoryInfo(

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -468,6 +468,24 @@ let DetectInconsistentVersionsInGitHubCIWorkflow6() =
 
 
 [<Test>]
+let DetectInconsistentVersionsInGitHubCIWorkflow7() =
+    let fileInfo =
+        (Seq.singleton(
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyCIWithoutSameNodeVersion.yml"
+                )
+            )
+        ))
+
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        Is.EqualTo true
+    )
+
+
+[<Test>]
 let DetectInconsistentVersionsInGitHubCI1() =
     let fileInfo =
         DirectoryInfo(

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -529,6 +529,21 @@ let DetectInconsistentVersionsInFSharpScripts1() =
         )
 
     Assert.That(
-        DetectInconsistentVersionsInFSharpScripts fileInfo,
+        DetectInconsistentVersionsInFSharpScripts fileInfo None,
         Is.EqualTo true
+    )
+
+
+[<Test>]
+let DetectInconsistentVersionsInFSharpScripts2() =
+    let dir =
+        DirectoryInfo(
+            Path.Combine(dummyFilesDirectory.FullName, "DummyScripts")
+        )
+
+    Assert.That(
+        DetectInconsistentVersionsInFSharpScripts
+            dir
+            (Some(Seq.singleton "DummyScripts")),
+        Is.EqualTo false
     )

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -447,3 +447,13 @@ let DetectInconsistentVersionsInGitHubCIWorkflow5() =
         DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
         Is.EqualTo true
     )
+
+
+[<Test>]
+let DetectInconsistentVersionsInGitHubCI1() =
+    let fileInfo =
+        DirectoryInfo(
+            Path.Combine(dummyFilesDirectory.FullName, "DummyWorkflows")
+        )
+
+    Assert.That(DetectInconsistentVersionsInGitHubCI fileInfo, Is.EqualTo true)

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -348,3 +348,35 @@ let WrapTextTest4() =
         + "characters."
 
     Assert.That(WrapText text characterCount, Is.EqualTo expectedResult)
+
+[<Test>]
+
+let DetectInconsistentVersionsInGitHubCIWorkflow1() =
+    let fileInfo =
+        (FileInfo(
+            Path.Combine(
+                dummyFilesDirectory.FullName,
+                "DummyCIWithSamePulumiVersion.yml"
+            )
+        ))
+
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        Is.EqualTo false
+    )
+
+
+[<Test>]
+let DetectInconsistentVersionsInGitHubCIWorkflow2() =
+    let fileInfo =
+        (FileInfo(
+            Path.Combine(
+                dummyFilesDirectory.FullName,
+                "DummyCIWithoutSamePulumiVersion.yml"
+            )
+        ))
+
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        Is.EqualTo true
+    )

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -380,3 +380,35 @@ let DetectInconsistentVersionsInGitHubCIWorkflow2() =
         DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
         Is.EqualTo true
     )
+
+
+[<Test>]
+let DetectInconsistentVersionsInGitHubCIWorkflow3() =
+    let fileInfo =
+        (FileInfo(
+            Path.Combine(
+                dummyFilesDirectory.FullName,
+                "DummyCIWithoutSameSetupPulumiVersion.yml"
+            )
+        ))
+
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        Is.EqualTo true
+    )
+
+
+[<Test>]
+let DetectInconsistentVersionsInGitHubCIWorkflow4() =
+    let fileInfo =
+        (FileInfo(
+            Path.Combine(
+                dummyFilesDirectory.FullName,
+                "DummyCIWithSameSetupPulumiVersion.yml"
+            )
+        ))
+
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        Is.EqualTo false
+    )

--- a/src/FileConventions.Test/FileConventions.Test.fsproj
+++ b/src/FileConventions.Test/FileConventions.Test.fsproj
@@ -25,4 +25,20 @@
     
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="DummyFiles\DummyFsprojWithAsterisk.fsproj" />
+    <None Include="DummyFiles\DummyWithShebang.fsx" />
+    <None Include="DummyFiles\DummyWithWrongShebang.fsx" />
+    <None Include="DummyFiles\DummyWithoutMissingVersionsInNugetPackageReferences.fsx" />
+    <None Include="DummyFiles\DummyEmpty.fsx" />
+    <None Include="DummyFiles\DummyWithLFLineEndings" />
+    <None Include="DummyFiles\DummyWithMixedLineEndings" />
+    <None Include="DummyFiles\DummyFsprojWithoutAsterisk.fsproj" />
+    <None Include="DummyFiles\DummyWithoutShebang.fsx" />
+    <None Include="DummyFiles\DummyCIWithLatestTag.yml" />
+    <None Include="DummyFiles\DummyWithoutNugetPackageReferences.fsx" />
+    <None Include="DummyFiles\DummyCIWithoutLatestTag.yml" />
+    <None Include="DummyFiles\DummyWithMissingVersionsInNugetPackageReferences.fsx" />
+    <None Include="DummyFiles\DummyWithCRLFLineEndings" />
+  </ItemGroup>
 </Project>

--- a/src/FileConventions.Test/FileConventions.Test.fsproj
+++ b/src/FileConventions.Test/FileConventions.Test.fsproj
@@ -42,5 +42,7 @@
     <None Include="DummyFiles\DummyWithCRLFLineEndings" />
     <None Include="DummyFiles\DummyCIWithoutSamePulumiVersion.yml" />
     <None Include="DummyFiles\DummyCIWithSamePulumiVersion.yml" />
+    <None Include="DummyFiles\DummyCIWithoutSameSetupPulumiVersion.yml" />
+    <None Include="DummyFiles\DummyCIWithSameSetupPulumiVersion.yml" />
   </ItemGroup>
 </Project>

--- a/src/FileConventions.Test/FileConventions.Test.fsproj
+++ b/src/FileConventions.Test/FileConventions.Test.fsproj
@@ -40,5 +40,7 @@
     <None Include="DummyFiles\DummyCIWithoutLatestTag.yml" />
     <None Include="DummyFiles\DummyWithMissingVersionsInNugetPackageReferences.fsx" />
     <None Include="DummyFiles\DummyWithCRLFLineEndings" />
+    <None Include="DummyFiles\DummyCIWithoutSamePulumiVersion.yml" />
+    <None Include="DummyFiles\DummyCIWithSamePulumiVersion.yml" />
   </ItemGroup>
 </Project>

--- a/src/FileConventions.Test/FileConventions.Test.fsproj
+++ b/src/FileConventions.Test/FileConventions.Test.fsproj
@@ -44,5 +44,7 @@
     <None Include="DummyFiles\DummyCIWithSamePulumiVersion.yml" />
     <None Include="DummyFiles\DummyCIWithoutSameSetupPulumiVersion.yml" />
     <None Include="DummyFiles\DummyCIWithSameSetupPulumiVersion.yml" />
+    <None Include="DummyFiles\DummyCIWithSetupPulumiVersionV2.0.0.yml" />
+    <None Include="DummyFiles\DummyCIWithSetupPulumiVersionV2.0.1.yml" />
   </ItemGroup>
 </Project>

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -303,3 +303,11 @@ let DetectInconsistentVersionsInGitHubCI(dir: DirectoryInfo) =
         false
     else
         DetectInconsistentVersionsInGitHubCIWorkflow ymlFiles
+
+let DetectInconsistentVersionsInNugetRefsInFSharpScripts
+    (fileInfos: seq<FileInfo>)
+    =
+    fileInfos
+    |> Seq.iter(fun fileInfo -> assert (fileInfo.FullName.EndsWith ".fsx"))
+
+    false

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -248,4 +248,13 @@ let WrapText (text: string) (maxCharsPerLine: int) : string =
 
 let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfo: FileInfo) =
     assert (fileInfo.FullName.EndsWith ".yml")
-    false
+    let fileLines = File.ReadLines fileInfo.FullName
+
+    let pulumiVersions =
+        fileLines
+        |> Seq.filter(fun line -> line.Contains "pulumi-version:")
+        |> Seq.map(fun line -> line.Substring(line.IndexOf(":") + 1))
+        |> Seq.map(fun line -> line.Trim())
+        |> Set.ofSeq
+
+    Seq.length pulumiVersions > 1

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -246,7 +246,8 @@ let WrapText (text: string) (maxCharsPerLine: int) : string =
         wrappedParagraphs
     )
 
-let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfo: FileInfo) =
+let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
+    let fileInfo = Seq.nth 0 fileInfos
     assert (fileInfo.FullName.EndsWith ".yml")
     let fileLines = File.ReadLines fileInfo.FullName
 

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -247,22 +247,35 @@ let WrapText (text: string) (maxCharsPerLine: int) : string =
     )
 
 let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
-    let fileInfo = Seq.nth 0 fileInfos
-    assert (fileInfo.FullName.EndsWith ".yml")
-    let fileLines = File.ReadLines fileInfo.FullName
+    fileInfos
+    |> Seq.iter(fun fileInfo -> assert (fileInfo.FullName.EndsWith ".yml"))
 
-    let pulumiVersions =
-        fileLines
-        |> Seq.filter(fun line -> line.Contains "pulumi-version:")
-        |> Seq.map(fun line -> line.Substring(line.IndexOf(":") + 1))
-        |> Seq.map(fun line -> line.Trim())
+    let inconsistentPulumiVersions =
+        fileInfos
+        |> Seq.map(fun fileInfo -> File.ReadLines fileInfo.FullName)
+        |> Seq.map(fun fileLines ->
+            fileLines
+            |> Seq.filter(fun line -> line.Contains "pulumi-version:")
+            |> Seq.map(fun line -> line.Substring(line.IndexOf(":") + 1))
+            |> Seq.map(fun line -> line.Trim())
+        )
+        |> Seq.concat
         |> Set.ofSeq
+        |> Seq.length
+        |> (fun length -> length > 1)
 
-    let setupPulumiVersions =
-        fileLines
-        |> Seq.filter(fun line -> line.Contains "setup-pulumi@")
-        |> Seq.map(fun line -> line.Substring(line.IndexOf("@") + 1))
-        |> Seq.map(fun line -> line.Trim())
+    let inconsistentSetupPulumiVersions =
+        fileInfos
+        |> Seq.map(fun fileInfo -> File.ReadLines fileInfo.FullName)
+        |> Seq.map(fun fileLines ->
+            fileLines
+            |> Seq.filter(fun line -> line.Contains "setup-pulumi@")
+            |> Seq.map(fun line -> line.Substring(line.IndexOf(":") + 1))
+            |> Seq.map(fun line -> line.Trim())
+        )
+        |> Seq.concat
         |> Set.ofSeq
+        |> Seq.length
+        |> (fun length -> length > 1)
 
-    Seq.length pulumiVersions > 1 || Seq.length setupPulumiVersions > 1
+    inconsistentPulumiVersions || inconsistentSetupPulumiVersions

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -318,8 +318,18 @@ let DetectInconsistentVersionsInFSharpScripts
     (dir: DirectoryInfo)
     (ignoreDirs: Option<seq<string>>)
     =
-    let fsxFiles = dir.GetFiles("*.fsx", SearchOption.AllDirectories)
-    printfn "%A" ignoreDirs
+    let fsxFiles =
+        match ignoreDirs with
+        | Some ignoreDirs ->
+            dir.GetFiles("*.fsx", SearchOption.AllDirectories)
+            |> Seq.filter(fun fileInfo ->
+                ignoreDirs
+                |> Seq.filter(fun ignoreDir ->
+                    fileInfo.FullName.Contains ignoreDir
+                )
+                |> (fun toBeIgnored -> Seq.length toBeIgnored = 0)
+            )
+        | None -> dir.GetFiles("*.fsx", SearchOption.AllDirectories)
 
     if Seq.length fsxFiles = 0 then
         false

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -245,3 +245,7 @@ let WrapText (text: string) (maxCharsPerLine: int) : string =
         $"{Environment.NewLine}{Environment.NewLine}",
         wrappedParagraphs
     )
+
+let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfo: FileInfo) =
+    assert (fileInfo.FullName.EndsWith ".yml")
+    false

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -314,8 +314,12 @@ let DetectInconsistentVersionsInNugetRefsInFSharpScripts
         fileInfos
         "#r \"nuget:\\s*([^\\s]*)\\s*,\\s*Version\\s*=\\s*([^\\s]*)\\s*\""
 
-let DetectInconsistentVersionsInFSharpScripts(dir: DirectoryInfo) =
+let DetectInconsistentVersionsInFSharpScripts
+    (dir: DirectoryInfo)
+    (ignoreDirs: Option<seq<string>>)
+    =
     let fsxFiles = dir.GetFiles("*.fsx", SearchOption.AllDirectories)
+    printfn "%A" ignoreDirs
 
     if Seq.length fsxFiles = 0 then
         false

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -280,7 +280,10 @@ let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
 
     inconsistentPulumiVersions || inconsistentSetupPulumiVersions
 
-
 let DetectInconsistentVersionsInGitHubCI(dir: DirectoryInfo) =
-    printfn "Path: %A" dir.FullName
-    false
+    let ymlFiles = dir.GetFiles("*.yml", SearchOption.AllDirectories)
+
+    if Seq.length ymlFiles = 0 then
+        false
+    else
+        DetectInconsistentVersionsInGitHubCIWorkflow ymlFiles

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -279,3 +279,8 @@ let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
         |> (fun length -> length > 1)
 
     inconsistentPulumiVersions || inconsistentSetupPulumiVersions
+
+
+let DetectInconsistentVersionsInGitHubCI(dir: DirectoryInfo) =
+    printfn "Path: %A" dir.FullName
+    false

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -18,8 +18,7 @@ let HasCorrectShebang(fileInfo: FileInfo) =
         false
 
 let MixedLineEndings(fileInfo: FileInfo) =
-    use streamReader = new StreamReader(fileInfo.FullName)
-    let fileText = streamReader.ReadToEnd()
+    let fileText = File.ReadAllText fileInfo.FullName
 
     let lf = Regex("[^\r]\n", RegexOptions.Compiled)
     let cr = Regex("\r[^\n]", RegexOptions.Compiled)
@@ -41,8 +40,8 @@ let MixedLineEndings(fileInfo: FileInfo) =
 
 let DetectUnpinnedVersionsInGitHubCI(fileInfo: FileInfo) =
     assert (fileInfo.FullName.EndsWith(".yml"))
-    use streamReader = new StreamReader(fileInfo.FullName)
-    let fileText = streamReader.ReadToEnd()
+
+    let fileText = File.ReadAllText fileInfo.FullName
 
     let latestTagInRunsOnRegex =
         Regex("runs-on: .*-latest", RegexOptions.Compiled)
@@ -69,8 +68,8 @@ let DetectUnpinnedDotnetToolInstallVersions(fileInfo: FileInfo) =
 
 let DetectAsteriskInPackageReferenceItems(fileInfo: FileInfo) =
     assert (fileInfo.FullName.EndsWith "proj")
-    use streamReader = new StreamReader(fileInfo.FullName)
-    let fileText = streamReader.ReadToEnd()
+
+    let fileText = File.ReadAllText fileInfo.FullName
 
     let asteriskInPackageReference =
         Regex(

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -313,3 +313,6 @@ let DetectInconsistentVersionsInNugetRefsInFSharpScripts
     DetectInconsistentVersion
         fileInfos
         "#r \"nuget:\\s*([^\\s]*)\\s*,\\s*Version\\s*=\\s*([^\\s]*)\\s*\""
+
+let DetectInconsistentVersionsInFSharpScripts(dir: DirectoryInfo) =
+    false

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -246,26 +246,11 @@ let WrapText (text: string) (maxCharsPerLine: int) : string =
         wrappedParagraphs
     )
 
-let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
-    fileInfos
-    |> Seq.iter(fun fileInfo -> assert (fileInfo.FullName.EndsWith ".yml"))
-
-    let inconsistentPulumiVersions =
-        fileInfos
-        |> Seq.map(fun fileInfo -> File.ReadLines fileInfo.FullName)
-        |> Seq.map(fun fileLines ->
-            fileLines
-            |> Seq.filter(fun line -> line.Contains "pulumi-version:")
-            |> Seq.map(fun line -> line.Substring(line.IndexOf(":") + 1))
-            |> Seq.map(fun line -> line.Trim())
-        )
-        |> Seq.concat
-        |> Set.ofSeq
-        |> Seq.length
-        |> (fun length -> length > 1)
-
-    let versionRegex =
-        Regex("\\suses:\\s*([^\\s]*)@v([^\\s]*)\\s", RegexOptions.Compiled)
+let DetectInconsistentVersion
+    (fileInfos: seq<FileInfo>)
+    (versionRegexPattern: string)
+    =
+    let versionRegex = Regex(versionRegexPattern, RegexOptions.Compiled)
 
     let mutable versionMap: Map<string, Set<string>> = Map.empty
 
@@ -291,12 +276,25 @@ let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
         )
     )
 
-    let inconsistentVersions =
-        versionMap
-        |> Seq.map(fun item -> Seq.length item.Value > 1)
-        |> Seq.contains true
+    versionMap
+    |> Seq.map(fun item -> Seq.length item.Value > 1)
+    |> Seq.contains true
 
-    inconsistentPulumiVersions || inconsistentVersions
+let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
+    fileInfos
+    |> Seq.iter(fun fileInfo -> assert (fileInfo.FullName.EndsWith ".yml"))
+
+    let inconsistentVersionsType1 =
+        DetectInconsistentVersion
+            fileInfos
+            "\\swith:\\s*([^\\s]*)-version:\\s*([^\\s]*)\\s"
+
+    let inconsistentVersionsType2 =
+        DetectInconsistentVersion
+            fileInfos
+            "\\suses:\\s*([^\\s]*)@v([^\\s]*)\\s"
+
+    inconsistentVersionsType1 || inconsistentVersionsType2
 
 let DetectInconsistentVersionsInGitHubCI(dir: DirectoryInfo) =
     let ymlFiles = dir.GetFiles("*.yml", SearchOption.AllDirectories)

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -310,4 +310,6 @@ let DetectInconsistentVersionsInNugetRefsInFSharpScripts
     fileInfos
     |> Seq.iter(fun fileInfo -> assert (fileInfo.FullName.EndsWith ".fsx"))
 
-    false
+    DetectInconsistentVersion
+        fileInfos
+        "#r \"nuget:\\s*([^\\s]*)\\s*,\\s*Version\\s*=\\s*([^\\s]*)\\s*\""

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -315,4 +315,9 @@ let DetectInconsistentVersionsInNugetRefsInFSharpScripts
         "#r \"nuget:\\s*([^\\s]*)\\s*,\\s*Version\\s*=\\s*([^\\s]*)\\s*\""
 
 let DetectInconsistentVersionsInFSharpScripts(dir: DirectoryInfo) =
-    false
+    let fsxFiles = dir.GetFiles("*.fsx", SearchOption.AllDirectories)
+
+    if Seq.length fsxFiles = 0 then
+        false
+    else
+        DetectInconsistentVersionsInNugetRefsInFSharpScripts fsxFiles

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -257,4 +257,11 @@ let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfo: FileInfo) =
         |> Seq.map(fun line -> line.Trim())
         |> Set.ofSeq
 
-    Seq.length pulumiVersions > 1
+    let setupPulumiVersions =
+        fileLines
+        |> Seq.filter(fun line -> line.Contains "setup-pulumi@")
+        |> Seq.map(fun line -> line.Substring(line.IndexOf("@") + 1))
+        |> Seq.map(fun line -> line.Trim())
+        |> Set.ofSeq
+
+    Seq.length pulumiVersions > 1 || Seq.length setupPulumiVersions > 1


### PR DESCRIPTION
Superseded https://github.com/nblockchain/conventions/pull/85