### PR TITLE
scripts/detectNotUsingGitPush1by1.fsx: fix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,6 +110,8 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: "ubuntu:22.04"
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Install required dependencies
         run: |


### PR DESCRIPTION
In private repositories, this script needs to use an access
token to be able to use GitHub api for accessing repository
info. In this commit I added Authentication header to GitHub
api requests.