### PR TITLE
Add a script to wrap the last commit msg body into a certain character count per line

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -9,6 +9,7 @@ This is a repository that contains several useful things that other `nblockchain
     * [F# scripts compilation](scripts/compileFSharpScripts.fsx).
     * [EOF without EOL detection](scripts/eofConvention.fsx).
     * [Mixed line-endings detection](scripts/mixedLineEndings.fsx).
+    * [Auto-wrap the latest commit message](scripts/wrapLatestCommitMsg.fsx).
     * Use of unpinned versions:
         * [Use of `-latest` suffix in `runs-on:` GitHubCI tags](scripts/unpinnedGitHubActionsImageVersions.fsx).
         * [Use of asterisk (*) in `PackageReference` items of .NET projects](scripts/unpinnedDotnetPackageVersions.fsx).

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -54,7 +54,6 @@ module.exports = {
     },
     plugins: [
         // TODO (ideas for more rules):
-        // * Detect if paragraphs in body have been cropped too shortly (less than 64 chars), and suggest same auto-wrap command that body-soft-max-line-length suggests, since it unwraps and wraps (both).
         // * Detect reverts which have not been elaborated.
         // * Reject some stupid obvious words: change, update, modify (if first word after colon, error; otherwise warning).
         // * Think of how to reject this shitty commit message: https://github.com/nblockchain/NOnion/pull/34/commits/9ffcb373a1147ed1c729e8aca4ffd30467255594

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -19,6 +19,11 @@ module.exports = {
             "always",
             bodyMaxLineLength,
         ],
+        "body-paragraph-line-min-length": [
+            RuleConfigSeverity.Error,
+            "always",
+            headerMaxLineLength,
+        ],
         "empty-wip": [RuleConfigSeverity.Error, "always"],
         "footer-leading-blank": [RuleConfigSeverity.Warning, "always"],
         "footer-max-line-length": [
@@ -202,6 +207,18 @@ module.exports = {
                     return Plugins.bodySoftMaxLineLength(
                         bodyStr,
                         maxLineLength
+                    );
+                },
+
+                "body-paragraph-line-min-length": (
+                    { body }: { body: any },
+                    _: any,
+                    minLineLength: number
+                ) => {
+                    let bodyStr = Helpers.convertAnyToString(body, "body");
+                    return Plugins.bodyParagraphLineMinLength(
+                        bodyStr,
+                        minLineLength
                     );
                 },
 

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -19,11 +19,7 @@ module.exports = {
             "always",
             bodyMaxLineLength,
         ],
-        "body-paragraph-line-min-length": [
-            RuleConfigSeverity.Error,
-            "always",
-            headerMaxLineLength,
-        ],
+        "body-paragraph-line-min-length": [RuleConfigSeverity.Error, "always"],
         "empty-wip": [RuleConfigSeverity.Error, "always"],
         "footer-leading-blank": [RuleConfigSeverity.Warning, "always"],
         "footer-max-line-length": [
@@ -210,15 +206,12 @@ module.exports = {
                     );
                 },
 
-                "body-paragraph-line-min-length": (
-                    { body }: { body: any },
-                    _: any,
-                    minLineLength: number
-                ) => {
+                "body-paragraph-line-min-length": ({ body }: { body: any }) => {
                     let bodyStr = Helpers.convertAnyToString(body, "body");
                     return Plugins.bodyParagraphLineMinLength(
                         bodyStr,
-                        minLineLength
+                        headerMaxLineLength,
+                        bodyMaxLineLength
                     );
                 },
 

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -323,6 +323,78 @@ test("body-max-line-length8", () => {
     expect(bodyMaxLineLength8.status).toBe(1);
 });
 
+test("body-paragraph-line-min-length1", () => {
+    let tenChars = "1234 67890";
+    let fortyChars = tenChars + tenChars + tenChars + tenChars;
+    let sixtyChars = fortyChars + tenChars + tenChars;
+    let commitMsgWithFortyCharsInBody =
+        "foo: this is only a title\n\n" + fortyChars + ".\n" + sixtyChars + ".";
+    let bodyParagraphLineMinLength1 = runCommitLintOnMsg(
+        commitMsgWithFortyCharsInBody
+    );
+    expect(bodyParagraphLineMinLength1.status).not.toBe(0);
+});
+
+test("body-paragraph-line-min-length2", () => {
+    let commitMsgWithCommitUrlAtTheEndOfBodyParagraph =
+        "foo: this is only a title\n\n" +
+        "Foo bar:\n" +
+        "https://github.com/username/repo/commit/1234567891234567891234567891234567891234";
+    let bodyParagraphLineMinLength2 = runCommitLintOnMsg(
+        commitMsgWithCommitUrlAtTheEndOfBodyParagraph
+    );
+
+    expect(bodyParagraphLineMinLength2.status).toBe(0);
+});
+
+test("body-paragraph-line-min-length3", () => {
+    let tenChars = "1234 67890";
+    let fortyChars = tenChars + tenChars + tenChars + tenChars;
+    let commitMsgWithFortyCharsInTheLastLineOfParagraph =
+        "foo: this is only a title\n\n" + fortyChars + ".";
+    let bodyParagraphLineMinLength3 = runCommitLintOnMsg(
+        commitMsgWithFortyCharsInTheLastLineOfParagraph
+    );
+    expect(bodyParagraphLineMinLength3.status).toBe(0);
+});
+
+test("body-paragraph-line-min-length4", () => {
+    let tenChars = "1234 67890";
+    let fortyChars = tenChars + tenChars + tenChars + tenChars;
+    let sixtyChars = fortyChars + tenChars + tenChars;
+    let commitMsgWithCodeBlockThatSubceedsBodyMinLineLength =
+        "foo: this is only a title" +
+        "\n\n" +
+        "Bar baz.\n```\n" +
+        fortyChars +
+        ".\n" +
+        sixtyChars +
+        "." +
+        "\n```";
+
+    let bodyParagraphLineMinLength4 = runCommitLintOnMsg(
+        commitMsgWithCodeBlockThatSubceedsBodyMinLineLength
+    );
+
+    // because ```blocks surrounded like this``` can bypass the limit
+    expect(bodyParagraphLineMinLength4.status).toBe(0);
+});
+
+test("body-paragraph-line-min-length5", () => {
+    let commitMsgWithCoAuthoredByTagThatSubceedsBodyMinLineLength =
+        "foo: this is only a title" +
+        "\n\n" +
+        "Co-authored-by: Jon Doe <shortmail@example.com>\n" +
+        "Co-authored-by: Jon Doe <JonDoeEmailAddress@example.com>";
+
+    let bodyParagraphLineMinLength5 = runCommitLintOnMsg(
+        commitMsgWithCoAuthoredByTagThatSubceedsBodyMinLineLength
+    );
+
+    // because Co-authored-by tags can bypass the limit
+    expect(bodyParagraphLineMinLength5.status).toBe(0);
+});
+
 test("commit-hash-alone1", () => {
     let commitMsgWithCommitUrl =
         "foo: this is only a title" +

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -395,6 +395,21 @@ test("body-paragraph-line-min-length5", () => {
     expect(bodyParagraphLineMinLength5.status).toBe(0);
 });
 
+test("body-paragraph-line-min-length6", () => {
+    let commitMsgThatSubceedsBodyMinLineLength =
+        "Some title of less than 50 chars" +
+        "\n\n" +
+        "This is a paragraph whose 2nd line is less than 50 chars\n" +
+        "but should not make commitlint complain because\n" +
+        "TheNextWordInThe3rdLineIsTooLongToBePlacedIn2ndLine.";
+
+    let bodyParagraphLineMinLength6 = runCommitLintOnMsg(
+        commitMsgThatSubceedsBodyMinLineLength
+    );
+
+    expect(bodyParagraphLineMinLength6.status).toBe(0);
+});
+
 test("commit-hash-alone1", () => {
     let commitMsgWithCommitUrl =
         "foo: this is only a title" +

--- a/commitlint/plugins.ts
+++ b/commitlint/plugins.ts
@@ -403,7 +403,8 @@ export abstract class Plugins {
 
     public static bodyParagraphLineMinLength(
         bodyStr: string | null,
-        paragraphLineMinLength: number
+        paragraphLineMinLength: number,
+        paragraphLineMaxLength: number
     ) {
         let offence = false;
 
@@ -414,14 +415,14 @@ export abstract class Plugins {
             for (let paragraph of paragraphs) {
                 let lines = paragraph.split(/\r?\n/);
                 let inBigBlock = false;
-                for (let i = 0; i < lines.length; i++) {
+                for (let i = 0; i < lines.length - 1; i++) {
                     let line = lines[i];
 
                     if (Helpers.isBigBlock(line)) {
                         inBigBlock = !inBigBlock;
                         continue;
                     }
-                    if (inBigBlock || i === lines.length - 1) {
+                    if (inBigBlock) {
                         continue;
                     }
 
@@ -434,11 +435,12 @@ export abstract class Plugins {
 
                         let lineIsFooterNote = Helpers.isFooterNote(line);
 
-                        if (
-                            !isUrl &&
-                            !lineIsFooterNote &&
-                            line !== lines[lines.length - 1]
-                        ) {
+                        let nextWordLength = lines[i + 1].split(" ")[0].length;
+                        let isNextWordTooLong =
+                            nextWordLength + line.length + 1 >
+                            paragraphLineMaxLength;
+
+                        if (!isUrl && !lineIsFooterNote && !isNextWordTooLong) {
                             offence = true;
                             break;
                         }

--- a/commitlint/plugins.ts
+++ b/commitlint/plugins.ts
@@ -401,6 +401,60 @@ export abstract class Plugins {
         ];
     }
 
+    public static bodyParagraphLineMinLength(
+        bodyStr: string | null,
+        paragraphLineMinLength: number
+    ) {
+        let offence = false;
+
+        if (bodyStr !== null) {
+            bodyStr = Helpers.removeAllCodeBlocks(bodyStr).trim();
+
+            let paragraphs = bodyStr.split(/\r?\n\r?\n/);
+            for (let paragraph of paragraphs) {
+                let lines = paragraph.split(/\r?\n/);
+                let inBigBlock = false;
+                for (let i = 0; i < lines.length; i++) {
+                    let line = lines[i];
+
+                    if (Helpers.isBigBlock(line)) {
+                        inBigBlock = !inBigBlock;
+                        continue;
+                    }
+                    if (inBigBlock || i === lines.length - 1) {
+                        continue;
+                    }
+
+                    let nextLine = lines[i + 1];
+
+                    if (line.length < paragraphLineMinLength) {
+                        let isUrl =
+                            Helpers.isValidUrl(line) ||
+                            Helpers.isValidUrl(nextLine);
+
+                        let lineIsFooterNote = Helpers.isFooterNote(line);
+
+                        if (
+                            !isUrl &&
+                            !lineIsFooterNote &&
+                            line !== lines[lines.length - 1]
+                        ) {
+                            offence = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return [
+            !offence,
+            `Please do not subceed ${paragraphLineMinLength} characters in the lines of the commit message's body paragraphs (except the last line of each paragraph); we recommend this script (for editing the last commit message): \n` +
+                "https://github.com/nblockchain/conventions/blob/master/scripts/wrapLatestCommitMsg.fsx" +
+                Helpers.errMessageSuffix,
+        ];
+    }
+
     public static trailingWhitespace(rawStr: string) {
         let offence = false;
 

--- a/commitlint/plugins.ts
+++ b/commitlint/plugins.ts
@@ -393,16 +393,10 @@ export abstract class Plugins {
             }
         }
 
-        // taken from https://stackoverflow.com/a/66433444/544947 and https://unix.stackexchange.com/a/25208/56844
-        function getUnixCommand(fmtOption: string) {
-            return `git log --format=%B -n 1 $(git log -1 --pretty=format:"%h") | cat - > log.txt ; fmt -w 1111 -s log.txt > ulog.txt && fmt -w 64 -s ${fmtOption} ulog.txt > wlog.txt && git commit --amend -F wlog.txt`;
-        }
-
         return [
             !offence,
-            `Please do not exceed ${bodyMaxLineLength} characters in the lines of the commit message's body; we recommend this unix command (for editing the last commit message): \n` +
-                `For Linux users: ${getUnixCommand("-u")}\n` +
-                `For macOS users: ${getUnixCommand("")}` +
+            `Please do not exceed ${bodyMaxLineLength} characters in the lines of the commit message's body; we recommend this script (for editing the last commit message): \n` +
+                "https://github.com/nblockchain/conventions/blob/master/scripts/wrapLatestCommitMsg.fsx" +
                 Helpers.errMessageSuffix,
         ];
     }

--- a/scripts/wrapLatestCommitMsg.fsx
+++ b/scripts/wrapLatestCommitMsg.fsx
@@ -1,0 +1,67 @@
+#!/usr/bin/env -S dotnet fsi
+
+open System.IO
+open System
+open System.Text.RegularExpressions
+
+#load "../src/FileConventions/Library.fs"
+
+#r "nuget: Fsdk, Version=0.6.0--date20230214-0422.git-1ea6f62"
+
+open Fsdk
+open Fsdk.Process
+
+let commitMsg =
+    Fsdk
+        .Process
+        .Execute(
+            {
+                Command = "git"
+                Arguments = "log -1 --format=%B"
+            },
+            Echo.Off
+        )
+        .UnwrapDefault()
+        .Trim()
+
+let header, maybeBody =
+    let newLineIndex = commitMsg.IndexOf Environment.NewLine
+
+    if newLineIndex > 0 then
+        commitMsg.Substring(0, newLineIndex).Trim(),
+        Some(commitMsg.Substring(newLineIndex).Trim())
+    else
+        commitMsg, None
+
+let maxCharsPerLine = 64
+
+let maybeWrappedBody =
+    match maybeBody with
+    | Some body -> Some(FileConventions.WrapText body maxCharsPerLine)
+    | _ -> None
+
+let EscapeDoubleQuotes(text: string) =
+    Regex.Replace(text, @"([^\\])""", @"$1\""")
+
+let newCommitMsg =
+    match maybeWrappedBody with
+    | Some wrappedBody ->
+        header
+        + Environment.NewLine
+        + Environment.NewLine
+        + wrappedBody
+        + Environment.NewLine
+    | _ -> header
+
+Fsdk
+    .Process
+    .Execute(
+        {
+            Command = "git"
+            Arguments =
+                $"commit --amend --message \"{EscapeDoubleQuotes newCommitMsg}\""
+        },
+        Echo.Off
+    )
+    .UnwrapDefault()
+    .Trim()

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -255,3 +255,18 @@ let HasBinaryContentTest3() =
         ))
 
     Assert.That(HasBinaryContent fileInfo, Is.EqualTo false)
+
+
+[<Test>]
+let WrapTextTest1() =
+    let characterCount = 64
+
+    let paragraph =
+        "This is a very very very very long line with more than 64 characters."
+
+    let expectedResult =
+        "This is a very very very very long line with more than 64"
+        + Environment.NewLine
+        + "characters."
+
+    Assert.That(WrapText paragraph characterCount, Is.EqualTo expectedResult)

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -287,3 +287,27 @@ let WrapTextTest2() =
     let expectedResult = paragraph
 
     Assert.That(WrapText paragraph characterCount, Is.EqualTo expectedResult)
+
+[<Test>]
+let WrapTextTest3() =
+    let characterCount = 64
+    let tenDigits = "1234567890"
+
+    let seventyChars =
+        tenDigits
+        + tenDigits
+        + tenDigits
+        + tenDigits
+        + tenDigits
+        + tenDigits
+        + tenDigits
+
+    let paragraph =
+        "This is short line referring to [1]."
+        + Environment.NewLine
+        + "[1] someUrl://"
+        + seventyChars
+
+    let expectedResult = paragraph
+
+    Assert.That(WrapText paragraph characterCount, Is.EqualTo expectedResult)

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -311,3 +311,24 @@ let WrapTextTest3() =
     let expectedResult = paragraph
 
     Assert.That(WrapText paragraph characterCount, Is.EqualTo expectedResult)
+
+
+[<Test>]
+let WrapTextTest4() =
+    let characterCount = 64
+
+    let text =
+        "This is short line."
+        + Environment.NewLine
+        + Environment.NewLine
+        + "This is a very very very very very long line with more than 64 characters."
+
+    let expectedResult =
+        "This is short line."
+        + Environment.NewLine
+        + Environment.NewLine
+        + "This is a very very very very very long line with more than 64"
+        + Environment.NewLine
+        + "characters."
+
+    Assert.That(WrapText text characterCount, Is.EqualTo expectedResult)

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -270,3 +270,20 @@ let WrapTextTest1() =
         + "characters."
 
     Assert.That(WrapText paragraph characterCount, Is.EqualTo expectedResult)
+
+[<Test>]
+let WrapTextTest2() =
+    let characterCount = 64
+
+    let paragraph =
+        "This is short line."
+        + Environment.NewLine
+        + "```"
+        + Environment.NewLine
+        + "This is a very very very very long line with more than 64 characters inside a code block."
+        + Environment.NewLine
+        + "```"
+
+    let expectedResult = paragraph
+
+    Assert.That(WrapText paragraph characterCount, Is.EqualTo expectedResult)

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -104,3 +104,9 @@ let EolAtEof(fileInfo: FileInfo) =
                 False
         else
             True
+
+let WrapText (text: string) (maxCharsPerLine: int) : string =
+    printfn
+        $"This function wraps \"{text}\" into a certain character count ({maxCharsPerLine}) per line."
+
+    ""

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -106,7 +106,33 @@ let EolAtEof(fileInfo: FileInfo) =
             True
 
 let WrapText (text: string) (maxCharsPerLine: int) : string =
-    printfn
-        $"This function wraps \"{text}\" into a certain character count ({maxCharsPerLine}) per line."
+    let rec splitIntoLines
+        (acc: list<string>)
+        (currLine: string)
+        (words: list<string>)
+        =
+        match words with
+        | [] -> currLine :: acc
+        | word :: rest ->
+            let newLineCharacterCount = currLine.Length + word.Length + 1
 
-    ""
+            let newAcc =
+                if newLineCharacterCount > maxCharsPerLine then
+                    currLine.Trim() :: acc
+                else
+                    acc
+
+            let newLine =
+                if newLineCharacterCount > maxCharsPerLine then
+                    word
+                else
+                    currLine + " " + word
+
+            splitIntoLines newAcc newLine rest
+
+    let words = text.Split([| ' ' |]) |> Array.toList
+
+    words.Tail
+    |> splitIntoLines [] words.Head
+    |> List.rev
+    |> String.concat Environment.NewLine

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -178,7 +178,7 @@ let SplitIntoWords(text: string) =
 
     words |> Seq.toList
 
-let WrapText (text: string) (maxCharsPerLine: int) : string =
+let private WrapParagraph (text: string) (maxCharsPerLine: int) : string =
     let words = SplitIntoWords text
 
     let mutable currentLine = ""
@@ -203,3 +203,13 @@ let WrapText (text: string) (maxCharsPerLine: int) : string =
             currentLine <- word.Text
 
     (wrappedText + currentLine).Trim()
+
+let WrapText (text: string) (maxCharsPerLine: int) : string =
+    let wrappedParagraphs =
+        text.Split $"{Environment.NewLine}{Environment.NewLine}"
+        |> Seq.map(fun paragraph -> WrapParagraph paragraph maxCharsPerLine)
+
+    String.Join(
+        $"{Environment.NewLine}{Environment.NewLine}",
+        wrappedParagraphs
+    )


### PR DESCRIPTION
Added the wrapLatestCommitMsg.fsx script to wrap the last commit
message while considering code blocks and footer notes including
references, Fixes and Closes and Co-authored by lines.