### PR TITLE
Fix error message for footernote references with EOL

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -114,7 +114,7 @@ module.exports = {
                 "footer-references-existence": ({ body }: { body: any }) => {
                     let bodyStr = Helpers.convertAnyToString(body, "body");
 
-                    return Plugins.footerReferencesExistence(bodyStr);
+                    return Plugins.footerReferencesValidity(bodyStr);
                 },
 
                 "prefer-slash-over-backslash": ({

--- a/commitlint/helpers.ts
+++ b/commitlint/helpers.ts
@@ -98,6 +98,15 @@ export abstract class Helpers {
         return isLowerCase && !isUpperCase;
     }
 
+    public static isEmptyFooterReference(line: string) {
+        Helpers.assertLine(line);
+        let trimmedLine = line.trim();
+        return (
+            trimmedLine[0] === "[" &&
+            trimmedLine.indexOf("]") === trimmedLine.length - 1
+        );
+    }
+
     public static isFooterReference(line: string) {
         Helpers.assertLine(line);
         return line[0] === "[" && line.indexOf("] ") > 0;

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -476,6 +476,19 @@ test("footer-references-existence4", () => {
     expect(footerReferenceExistence4.status).toBe(0);
 });
 
+test("footer-references-with-EOL", () => {
+    let commmitMsgwithEOLFooter =
+        "foo: this is only a title" +
+        "\n\n" +
+        "Bla bla blah[1]." +
+        "\n\n" +
+        "[1]\nhttp://foo.bar/baz";
+    let footerReferenceWithEOL = runCommitLintOnMsg(commmitMsgwithEOLFooter);
+    expect(footerReferenceWithEOL.output[1].toString().includes("EOL")).toBe(
+        true
+    );
+});
+
 test("prefer-slash-over-backslash1", () => {
     let commitMsgWithBackslash = "foo\\bar: bla bla bla";
     let preferSlashOverBackslash1 = runCommitLintOnMsg(commitMsgWithBackslash);

--- a/commitlint/plugins.ts
+++ b/commitlint/plugins.ts
@@ -181,8 +181,9 @@ export abstract class Plugins {
         ];
     }
 
-    public static footerReferencesExistence(bodyStr: string | null) {
+    public static footerReferencesValidity(bodyStr: string | null) {
         let offence = false;
+        let hasEmptyFooter = false;
 
         if (bodyStr !== null) {
             bodyStr = bodyStr.trim();
@@ -195,7 +196,10 @@ export abstract class Plugins {
                     continue;
                 }
                 for (let match of matches) {
-                    if (Helpers.isFooterReference(line)) {
+                    if (Helpers.isEmptyFooterReference(line)) {
+                        offence = true;
+                        hasEmptyFooter = true;
+                    } else if (Helpers.isFooterReference(line)) {
                         references.add(match);
                     } else {
                         bodyReferences.add(match);
@@ -216,11 +220,15 @@ export abstract class Plugins {
             }
         }
 
-        return [
-            !offence,
-            "All references in the body must be mentioned in the footer, and vice versa." +
-                Helpers.errMessageSuffix,
-        ];
+        let errorMessage =
+            "All references in the body must be mentioned in the footer, and vice versa.";
+
+        if (hasEmptyFooter) {
+            errorMessage =
+                "A footer reference can not be empty, please make sure that you've provided the reference and there is no EOL between the reference number and the reference.";
+        }
+
+        return [!offence, errorMessage + Helpers.errMessageSuffix];
     }
 
     public static preferSlashOverBackslash(headerStr: string) {


### PR DESCRIPTION
When we have a commit with EOL after "[]" then we get a confusing error about the reference not existing. In this PR I first check if a reference number has no reference and give a different error about it.