### PR TITLE
commitlint: fix double false positive (2 rules)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ TestResults.xml
 *.[Cc]ache
 # but keep track of directories ending in .cache
 !*.[Cc]ache/
+
+# Ionide-related
+.fake

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -113,10 +113,13 @@ module.exports = {
                     return Plugins.footerNotesMisplacement(bodyStr);
                 },
 
-                "footer-references-validity": ({ body }: { body: any }) => {
-                    let bodyStr = Helpers.convertAnyToString(body, "body");
+                "footer-references-validity": ({ raw }: { raw: any }) => {
+                    let rawStr = Helpers.assertNotNull(
+                        Helpers.convertAnyToString(raw, "raw"),
+                        notNullStringErrorMessage("raw")
+                    );
 
-                    return Plugins.footerReferencesValidity(bodyStr);
+                    return Plugins.footerReferencesValidity(rawStr);
                 },
 
                 "prefer-slash-over-backslash": ({

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -45,7 +45,9 @@ module.exports = {
         "prefer-slash-over-backslash": [RuleConfigSeverity.Error, "always"],
         "type-space-before-paren": [RuleConfigSeverity.Error, "always"],
         "type-with-square-brackets": [RuleConfigSeverity.Error, "always"],
+        /* disabled until a related problem is fixed first in another rule
         "proper-issue-refs": [RuleConfigSeverity.Error, "always"],
+        */
         "too-many-spaces": [RuleConfigSeverity.Error, "always"],
         "commit-hash-alone": [RuleConfigSeverity.Error, "always"],
         "title-uppercase": [RuleConfigSeverity.Error, "always"],

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -28,7 +28,9 @@ module.exports = {
             footerMaxLineLength,
         ],
         "footer-notes-misplacement": [RuleConfigSeverity.Error, "always"],
+        /* disabled until a related problem is fixed first in another rule
         "footer-references-validity": [RuleConfigSeverity.Error, "always"],
+        */
         "header-max-length-with-suggestions": [
             RuleConfigSeverity.Error,
             "always",

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -28,7 +28,7 @@ module.exports = {
             footerMaxLineLength,
         ],
         "footer-notes-misplacement": [RuleConfigSeverity.Error, "always"],
-        "footer-references-validity": [RuleConfigSeverity.Error, "always"],
+        "footer-refs-validity": [RuleConfigSeverity.Error, "always"],
         "header-max-length-with-suggestions": [
             RuleConfigSeverity.Error,
             "always",
@@ -113,13 +113,13 @@ module.exports = {
                     return Plugins.footerNotesMisplacement(bodyStr);
                 },
 
-                "footer-references-validity": ({ raw }: { raw: any }) => {
+                "footer-refs-validity": ({ raw }: { raw: any }) => {
                     let rawStr = Helpers.assertNotNull(
                         Helpers.convertAnyToString(raw, "raw"),
                         notNullStringErrorMessage("raw")
                     );
 
-                    return Plugins.footerReferencesValidity(rawStr);
+                    return Plugins.footerRefsValidity(rawStr);
                 },
 
                 "prefer-slash-over-backslash": ({

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -43,9 +43,7 @@ module.exports = {
         "prefer-slash-over-backslash": [RuleConfigSeverity.Error, "always"],
         "type-space-before-paren": [RuleConfigSeverity.Error, "always"],
         "type-with-square-brackets": [RuleConfigSeverity.Error, "always"],
-        /* disabled until a related problem is fixed first in another rule
         "proper-issue-refs": [RuleConfigSeverity.Error, "always"],
-        */
         "too-many-spaces": [RuleConfigSeverity.Error, "always"],
         "commit-hash-alone": [RuleConfigSeverity.Error, "always"],
         "title-uppercase": [RuleConfigSeverity.Error, "always"],

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -28,9 +28,7 @@ module.exports = {
             footerMaxLineLength,
         ],
         "footer-notes-misplacement": [RuleConfigSeverity.Error, "always"],
-        /* disabled until a related problem is fixed first in another rule
         "footer-references-validity": [RuleConfigSeverity.Error, "always"],
-        */
         "header-max-length-with-suggestions": [
             RuleConfigSeverity.Error,
             "always",

--- a/commitlint/helpers.ts
+++ b/commitlint/helpers.ts
@@ -166,7 +166,10 @@ export abstract class Helpers {
     }
 
     public static includesHashtagRef(text: string) {
-        return text.match(`\\s+#[0-9]+`) !== null;
+        return (
+            text.match(`\\s+#[0-9]+`) !== null ||
+            text.match(`^#[0-9]+`) !== null
+        );
     }
 
     public static removeAllCodeBlocks(text: string) {

--- a/commitlint/helpers.ts
+++ b/commitlint/helpers.ts
@@ -166,7 +166,7 @@ export abstract class Helpers {
     }
 
     public static includesHashtagRef(text: string) {
-        return text.match(`#[0-9]+`) !== null;
+        return text.match(`\\s+#[0-9]+`) !== null;
     }
 
     public static removeAllCodeBlocks(text: string) {

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -583,7 +583,9 @@ test("footer-references-validity6", () => {
         "Blah blah blah[1]." +
         "\n\n" +
         "[1] https://somehost/somePath/someRes#7-some-numbered-anchor";
-    let footerReferencesValidity6 = runCommitLintOnMsg(commitMsgWithUrlContainingAnchor);
+    let footerReferencesValidity6 = runCommitLintOnMsg(
+        commitMsgWithUrlContainingAnchor
+    );
     expect(footerReferencesValidity6.status).toBe(0);
 });
 

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -752,6 +752,13 @@ test("proper-issue-refs3", () => {
     expect(properIssueRefs3.status).toBe(0);
 });
 
+test("proper-issue-refs4", () => {
+    let commitMsgWithFullUrl =
+        "foo: blah blah" + "\n\n" + "It turns out that robocopy might fail when copying timestamp\nattributes because exFat[1]'s spec says times need to be later\nthan 1980 [2].\n\n[1] https://superuser.com/a/1447347/600757\n[2] https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#7486-year-field";
+    let properIssueRefs4 = runCommitLintOnMsg(commitMsgWithFullUrl);
+    expect(properIssueRefs4.status).toBe(0);
+});
+
 test("subject-lowercase1", () => {
     let commitMsgWithUppercaseAfterColon = "foo: Bar baz";
     let subjectLowerCase1 = runCommitLintOnMsg(

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -754,7 +754,9 @@ test("proper-issue-refs3", () => {
 
 test("proper-issue-refs4", () => {
     let commitMsgWithFullUrl =
-        "foo: blah blah" + "\n\n" + "It turns out that robocopy might fail when copying timestamp\nattributes because exFat[1]'s spec says times need to be later\nthan 1980 [2].\n\n[1] https://superuser.com/a/1447347/600757\n[2] https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#7486-year-field";
+        "foo: blah blah" +
+        "\n\n" +
+        "Some paragraph text with a ref[1].\n\n[1] someUrl://someHostName/someFolder/someResource#666-anchor";
     let properIssueRefs4 = runCommitLintOnMsg(commitMsgWithFullUrl);
     expect(properIssueRefs4.status).toBe(0);
 });

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -577,9 +577,13 @@ test("footer-references-validity5", () => {
 });
 
 test("footer-references-validity6", () => {
-    let commitMsg =
-        "foo: blah blah" + "\n\n" + "It turns out that robocopy might fail when copying timestamp\nattributes because exFat[1]'s spec says times need to be later\nthan 1980 [2].\n\n[1] https://superuser.com/a/1447347/600757\n[2] https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#7486-year-field";
-    let footerReferencesValidity6 = runCommitLintOnMsg(commitMsg);
+    let commitMsgWithUrlContainingAnchor =
+        "foo: blah blah" +
+        "\n\n" +
+        "Blah blah blah[1]." +
+        "\n\n" +
+        "[1] https://somehost/somePath/someRes#7-some-numbered-anchor";
+    let footerReferencesValidity6 = runCommitLintOnMsg(commitMsgWithUrlContainingAnchor);
     expect(footerReferencesValidity6.status).toBe(0);
 });
 

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -508,7 +508,7 @@ test("footer-notes-misplacement-4", () => {
     let footerNotesMisplacement4 = runCommitLintOnMsg(commitMsgWithWrongFooter);
     expect(footerNotesMisplacement4.status).not.toBe(0);
 });
-/*
+
 test("footer-references-validity1", () => {
     let commmitMsgwithCorrectFooter =
         "foo: this is only a title" +
@@ -575,7 +575,7 @@ test("footer-references-validity5", () => {
         true
     );
 });
-*/
+
 test("prefer-slash-over-backslash1", () => {
     let commitMsgWithBackslash = "foo\\bar: bla bla bla";
     let preferSlashOverBackslash1 = runCommitLintOnMsg(commitMsgWithBackslash);

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -508,7 +508,7 @@ test("footer-notes-misplacement-4", () => {
     let footerNotesMisplacement4 = runCommitLintOnMsg(commitMsgWithWrongFooter);
     expect(footerNotesMisplacement4.status).not.toBe(0);
 });
-
+/*
 test("footer-references-validity1", () => {
     let commmitMsgwithCorrectFooter =
         "foo: this is only a title" +
@@ -575,7 +575,7 @@ test("footer-references-validity5", () => {
         true
     );
 });
-
+*/
 test("prefer-slash-over-backslash1", () => {
     let commitMsgWithBackslash = "foo\\bar: bla bla bla";
     let preferSlashOverBackslash1 = runCommitLintOnMsg(commitMsgWithBackslash);

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -576,6 +576,13 @@ test("footer-references-validity5", () => {
     );
 });
 
+test("footer-references-validity6", () => {
+    let commitMsg =
+        "foo: blah blah" + "\n\n" + "It turns out that robocopy might fail when copying timestamp\nattributes because exFat[1]'s spec says times need to be later\nthan 1980 [2].\n\n[1] https://superuser.com/a/1447347/600757\n[2] https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#7486-year-field";
+    let footerReferencesValidity6 = runCommitLintOnMsg(commitMsg);
+    expect(footerReferencesValidity6.status).toBe(0);
+});
+
 test("prefer-slash-over-backslash1", () => {
     let commitMsgWithBackslash = "foo\\bar: bla bla bla";
     let preferSlashOverBackslash1 = runCommitLintOnMsg(commitMsgWithBackslash);

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -734,7 +734,7 @@ test("header-max-length-with-suggestions12", () => {
         (headerMaxLength12.stdout + "").includes(not_expected_message)
     ).toEqual(false);
 });
-/*
+
 test("proper-issue-refs1", () => {
     let commitMsgWithHashtagRef = "foo: blah blah" + "\n\n" + "Blah blah #123.";
     let properIssueRefs1 = runCommitLintOnMsg(commitMsgWithHashtagRef);
@@ -772,7 +772,7 @@ test("proper-issue-refs5", () => {
     let properIssueRefs5 = runCommitLintOnMsg(commitMsgWithHashtagRef);
     expect(properIssueRefs5.status).not.toBe(0);
 });
-*/
+
 test("subject-lowercase1", () => {
     let commitMsgWithUppercaseAfterColon = "foo: Bar baz";
     let subjectLowerCase1 = runCommitLintOnMsg(

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -729,7 +729,7 @@ test("header-max-length-with-suggestions12", () => {
         (headerMaxLength12.stdout + "").includes(not_expected_message)
     ).toEqual(false);
 });
-
+/*
 test("proper-issue-refs1", () => {
     let commitMsgWithHashtagRef = "foo: blah blah" + "\n\n" + "Blah blah #123.";
     let properIssueRefs1 = runCommitLintOnMsg(commitMsgWithHashtagRef);
@@ -767,7 +767,7 @@ test("proper-issue-refs5", () => {
     let properIssueRefs5 = runCommitLintOnMsg(commitMsgWithHashtagRef);
     expect(properIssueRefs5.status).not.toBe(0);
 });
-
+*/
 test("subject-lowercase1", () => {
     let commitMsgWithUppercaseAfterColon = "foo: Bar baz";
     let subjectLowerCase1 = runCommitLintOnMsg(

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -509,34 +509,30 @@ test("footer-notes-misplacement-4", () => {
     expect(footerNotesMisplacement4.status).not.toBe(0);
 });
 
-test("footer-references-validity1", () => {
-    let commmitMsgwithCorrectFooter =
+test("footer-refs-validity1", () => {
+    let commmitMsgWithCorrectFooter =
         "foo: this is only a title" +
         "\n\n" +
         "Bla bla blah[1]." +
         "\n\n" +
         "[1] http://foo.bar/baz";
-    let footerReferenceValidity1 = runCommitLintOnMsg(
-        commmitMsgwithCorrectFooter
-    );
-    expect(footerReferenceValidity1.status).toBe(0);
+    let footerRefsValidity1 = runCommitLintOnMsg(commmitMsgWithCorrectFooter);
+    expect(footerRefsValidity1.status).toBe(0);
 });
 
-test("footer-references-validity2", () => {
-    let commmitMsgwithWrongFooter =
+test("footer-refs-validity2", () => {
+    let commmitMsgWithWrongFooter =
         "foo: this is only a title" +
         "\n\n" +
         "Bla bla blah." +
         "\n\n" +
         "[1] http://foo.bar/baz";
-    let footerReferenceValidity2 = runCommitLintOnMsg(
-        commmitMsgwithWrongFooter
-    );
-    expect(footerReferenceValidity2.status).not.toBe(0);
+    let footerRefsValidity2 = runCommitLintOnMsg(commmitMsgWithWrongFooter);
+    expect(footerRefsValidity2.status).not.toBe(0);
 });
 
-test("footer-references-validity3", () => {
-    let commmitMsgwithWrongFooter =
+test("footer-refs-validity3", () => {
+    let commmitMsgWithWrongFooter =
         "foo: this is only a title" +
         "\n\n" +
         "Bla bla blah[1], and after that [2], then [3]." +
@@ -544,14 +540,12 @@ test("footer-references-validity3", () => {
         "[1] http://foo.bar/baz" +
         "\n\n" +
         "[2] http://foo.bar/baz";
-    let footerReferenceValidity3 = runCommitLintOnMsg(
-        commmitMsgwithWrongFooter
-    );
-    expect(footerReferenceValidity3.status).not.toBe(0);
+    let footerRefsValidity3 = runCommitLintOnMsg(commmitMsgWithWrongFooter);
+    expect(footerRefsValidity3.status).not.toBe(0);
 });
 
-test("footer-references-validity4", () => {
-    let commmitMsgwithFooter =
+test("footer-refs-validity4", () => {
+    let commmitMsgWithFooter =
         "Backend/Ether: catch/retry new -32002 err code\n\n" +
         "CI on master branch caught this[1]:\n" +
         "```\nUnhandled Exception:\n" +
@@ -559,34 +553,32 @@ test("footer-references-validity4", () => {
         "The end of the paragraph.\n\n" +
         "[1] https://github.com/nblockchain/geewallet/actions/runs/3507005645/jobs/5874411684";
 
-    let footerReferenceValidity4 = runCommitLintOnMsg(commmitMsgwithFooter);
-    expect(footerReferenceValidity4.status).toBe(0);
+    let footerRefsValidity4 = runCommitLintOnMsg(commmitMsgWithFooter);
+    expect(footerRefsValidity4.status).toBe(0);
 });
 
-test("footer-references-validity5", () => {
-    let commmitMsgwithEOLFooter =
+test("footer-refs-validity5", () => {
+    let commmitMsgWithEOLFooter =
         "foo: this is only a title" +
         "\n\n" +
         "Bla bla blah[1]." +
         "\n\n" +
         "[1]\nhttp://foo.bar/baz";
-    let footerReferenceValidity5 = runCommitLintOnMsg(commmitMsgwithEOLFooter);
-    expect(footerReferenceValidity5.output[1].toString().includes("EOL")).toBe(
-        true
-    );
+    let footerRefsValidity5 = runCommitLintOnMsg(commmitMsgWithEOLFooter);
+    expect(footerRefsValidity5.output[1].toString().includes("EOL")).toBe(true);
 });
 
-test("footer-references-validity6", () => {
+test("footer-refs-validity6", () => {
     let commitMsgWithUrlContainingAnchor =
         "foo: blah blah" +
         "\n\n" +
         "Blah blah blah[1]." +
         "\n\n" +
         "[1] https://somehost/somePath/someRes#7-some-numbered-anchor";
-    let footerReferencesValidity6 = runCommitLintOnMsg(
+    let footerRefsValidity6 = runCommitLintOnMsg(
         commitMsgWithUrlContainingAnchor
     );
-    expect(footerReferencesValidity6.status).toBe(0);
+    expect(footerRefsValidity6.status).toBe(0);
 });
 
 test("prefer-slash-over-backslash1", () => {

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -761,6 +761,13 @@ test("proper-issue-refs4", () => {
     expect(properIssueRefs4.status).toBe(0);
 });
 
+test("proper-issue-refs5", () => {
+    let commitMsgWithHashtagRef =
+        "foo: blah blah" + "\n\n" + "#123 bug is fixed.";
+    let properIssueRefs5 = runCommitLintOnMsg(commitMsgWithHashtagRef);
+    expect(properIssueRefs5.status).not.toBe(0);
+});
+
 test("subject-lowercase1", () => {
     let commitMsgWithUppercaseAfterColon = "foo: Bar baz";
     let subjectLowerCase1 = runCommitLintOnMsg(

--- a/commitlint/plugins.ts
+++ b/commitlint/plugins.ts
@@ -11,7 +11,7 @@ export abstract class Plugins {
         if (lineBreakIndex >= 0) {
             // Extracting bodyStr from rawStr rather than using body directly is a
             // workaround for https://github.com/conventional-changelog/commitlint/issues/3412
-            let bodyStr = rawStr.substring(lineBreakIndex);
+            let bodyStr = rawStr.substring(lineBreakIndex).trim();
 
             bodyStr = Helpers.removeAllCodeBlocks(bodyStr).trim();
 
@@ -258,7 +258,8 @@ export abstract class Plugins {
         if (lineBreakIndex >= 0) {
             // Extracting bodyStr from rawStr rather than using body directly is a
             // workaround for https://github.com/conventional-changelog/commitlint/issues/3412
-            let bodyStr = rawStr.substring(lineBreakIndex);
+            let bodyStr = rawStr.substring(lineBreakIndex).trim();
+
             bodyStr = Helpers.removeAllCodeBlocks(bodyStr);
             offence = Helpers.includesHashtagRef(bodyStr);
         }

--- a/commitlint/plugins.ts
+++ b/commitlint/plugins.ts
@@ -181,12 +181,18 @@ export abstract class Plugins {
         ];
     }
 
-    public static footerReferencesValidity(bodyStr: string | null) {
+    public static footerReferencesValidity(rawStr: string) {
         let offence = false;
         let hasEmptyFooter = false;
 
-        if (bodyStr !== null) {
-            bodyStr = bodyStr.trim();
+        rawStr = rawStr.trim();
+        let lineBreakIndex = rawStr.indexOf("\n");
+
+        if (lineBreakIndex >= 0) {
+            // Extracting bodyStr from rawStr rather than using body directly is a
+            // workaround for https://github.com/conventional-changelog/conventional-changelog/issues/1016
+            let bodyStr = rawStr.substring(lineBreakIndex).trim();
+
             let lines = bodyStr.split(/\r?\n/);
             let bodyReferences = new Set();
             let references = new Set();

--- a/commitlint/plugins.ts
+++ b/commitlint/plugins.ts
@@ -181,7 +181,7 @@ export abstract class Plugins {
         ];
     }
 
-    public static footerReferencesValidity(rawStr: string) {
+    public static footerRefsValidity(rawStr: string) {
         let offence = false;
         let hasEmptyFooter = false;
 


### PR DESCRIPTION
Fix for double (2 rules) false positive that happened in
commitlint step of fsx repo [1] ([2]).

[1] https://github.com/nblockchain/fsx/commit/bb58c43a565b4ba717e5f0ce1f1007db7371f546
[2] https://github.com/nblockchain/fsx/actions/runs/5231049113/jobs/9449654778