### PR TITLE
wrapLatestCommitMsg: fix behaviour in windows

### DIFF
--- a/scripts/wrapLatestCommitMsg.fsx
+++ b/scripts/wrapLatestCommitMsg.fsx
@@ -25,13 +25,21 @@ let commitMsg =
         .Trim()
 
 let header, maybeBody =
-    let newLineIndex = commitMsg.IndexOf Environment.NewLine
+    // We only want to split the msg into two parts (header and body)
+    let acceptablePartCount = 2
+    let separatorEolCount = 1
 
-    if newLineIndex > 0 then
-        commitMsg.Substring(0, newLineIndex).Trim(),
-        Some(commitMsg.Substring(newLineIndex).Trim())
+    let msgParts =
+        FileConventions.SplitByEOLs
+            commitMsg
+            separatorEolCount
+            StringSplitOptions.RemoveEmptyEntries
+            (Some acceptablePartCount)
+
+    if msgParts.Length > 1 then
+        msgParts.[0].Trim(), Some(msgParts.[1].Trim())
     else
-        commitMsg, None
+        msgParts.[0].Trim(), None
 
 let maxCharsPerLine = 64
 


### PR DESCRIPTION
While putting Environment.NewLine in output doesn't cause any problems expecting Environment.NewLine in input commit msgs causes problem in windows, so while keeping Environment.NewLine for output we change input processing to split by unix newline.

Fixes https://github.com/nblockchain/conventions/issues/123