### PR TITLE
Fix body prose false positive

### DIFF
--- a/commitlint/helpers.ts
+++ b/commitlint/helpers.ts
@@ -188,8 +188,8 @@ export abstract class Helpers {
         let macEol = "\r";
 
         let preparedText = text
-            .replace(windowsEol, unixEol)
-            .replace(macEol, unixEol);
+            .replaceAll(windowsEol, unixEol)
+            .replaceAll(macEol, unixEol);
 
         let separator = "";
         do {

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -175,6 +175,16 @@ test("body-prose16", () => {
     expect(bodyProse16.status).toBe(0);
 });
 
+test("body-prose17", () => {
+    let commitMsgWithWindowsEOL =
+        "title: this is only title\r\n\r\n" +
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit\r\n" +
+        "lorem ipsum dolor sit amet, consectetur porttitor jidga\r\n" +
+        "nam sed porttitor turpis, vitae erat curae.";
+    let bodyProse17 = runCommitLintOnMsg(commitMsgWithWindowsEOL);
+    expect(bodyProse17.status).toBe(0);
+});
+
 test("body-max-line-length1", () => {
     let tenChars = "1234 67890";
     let sixtyChars =


### PR DESCRIPTION
The `replace()` method does not replace all. Use `replaceall()` to resolve issue #134 .