### PR TITLE
scripts: fix wrapLatestCommitMsg's output commit

### DIFF
--- a/scripts/wrapLatestCommitMsg.fsx
+++ b/scripts/wrapLatestCommitMsg.fsx
@@ -48,11 +48,7 @@ let EscapeDoubleQuotes(text: string) =
 let newCommitMsg =
     match maybeWrappedBody with
     | Some wrappedBody ->
-        header
-        + Environment.NewLine
-        + Environment.NewLine
-        + wrappedBody
-        + Environment.NewLine
+        header + Environment.NewLine + Environment.NewLine + wrappedBody
     | _ -> header
 
 Fsdk


### PR DESCRIPTION
The wrapLatestCommitMsg.fsx script added a new line after the body. This new line is removed in this commit.

Fixes https://github.com/nblockchain/conventions/issues/116