### PR TITLE
commitlint/helpers.ts: weaken footer refs format

### DIFF
--- a/commitlint/helpers.ts
+++ b/commitlint/helpers.ts
@@ -113,7 +113,7 @@ export abstract class Helpers {
 
     public static isFooterReference(line: string) {
         Helpers.assertLine(line);
-        return line[0] === "[" && line.indexOf("] ") > 0;
+        return line[0] === "[" && line.indexOf("] ") > 1;
     }
 
     public static isFixesOrClosesSentence(line: string) {

--- a/commitlint/helpers.ts
+++ b/commitlint/helpers.ts
@@ -113,7 +113,7 @@ export abstract class Helpers {
 
     public static isFooterReference(line: string) {
         Helpers.assertLine(line);
-        return line[0] === "[" && line.indexOf("] ") > 1;
+        return line[0] === "[" && line.indexOf("]") > 1;
     }
 
     public static isFixesOrClosesSentence(line: string) {

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -664,6 +664,23 @@ test("footer-refs-validity7", () => {
     expect(footerRefsValidity7.status).toBe(0);
 });
 
+// This test reflects this issue: https://github.com/nblockchain/conventions/issues/146
+test("footer-refs-validity8", () => {
+    let commitMsgWithCodeBlockAtFooterRef =
+        "foo: blah blah" +
+        "\n\n" +
+        "Blah blah blah[1]." +
+        "\n\n" +
+        "[1]:\n" +
+        "```\n" +
+        "someCodeBlock\n" +
+        "```";
+    let footerRefsValidity8 = runCommitLintOnMsg(
+        commitMsgWithCodeBlockAtFooterRef
+    );
+    expect(footerRefsValidity8.status).toBe(0);
+});
+
 test("prefer-slash-over-backslash1", () => {
     let commitMsgWithBackslash = "foo\\bar: bla bla bla";
     let preferSlashOverBackslash1 = runCommitLintOnMsg(commitMsgWithBackslash);


### PR DESCRIPTION
This way we can make a footer ref be a code block, like:

```
[1]:
<SOMECODEBLOCK>
```

Fixes https://github.com/nblockchain/conventions/issues/146