### PR TITLE
CI: add compile typescript step

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,9 +102,7 @@ jobs:
       - name: Run typescript compiler
         # This step is needed because jest would swallow any compiler error
         # and just declare test as failed without any explanation.
-        run: |
-          echo "{}" > ./tsconfig.json
-          npx tsc
+        run: npx tsc
       - name: Run tests to validate our plugins
         run: yarn jest
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,6 +99,12 @@ jobs:
           npm --version
           npx commitlint --version
           yarn --version
+      - name: Run typescript compiler
+        # This step is needed because jest would swallow any compiler error
+        # and just declare test as failed without any explanation.
+        run: |
+          echo "{}" > ./tsconfig.json
+          npx tsc
       - name: Run tests to validate our plugins
         run: yarn jest
 

--- a/commitlint/integration.test.ts
+++ b/commitlint/integration.test.ts
@@ -1,10 +1,4 @@
-let cp = require("child_process");
-
-function runCommitLintOnMsg(inputMsg: string) {
-    return cp.spawnSync("npx", ["commitlint", "--verbose"], {
-        input: inputMsg,
-    });
-}
+import { runCommitLintOnMsg } from "./testHelpers";
 
 test("body-leading-blank1", () => {
     let commitMsgWithoutEmptySecondLine =

--- a/commitlint/plugins.test.ts
+++ b/commitlint/plugins.test.ts
@@ -1,8 +1,4 @@
-const { spawnSync } = require("child_process");
-
-function runCommitLintOnMsg(inputMsg: string) {
-    return spawnSync("npx", ["commitlint", "--verbose"], { input: inputMsg });
-}
+import { runCommitLintOnMsg } from "./testHelpers";
 
 test("body-prose1", () => {
     let commitMsgWithLowercaseBodyStart = `foo: this is only a title

--- a/commitlint/plugins.ts
+++ b/commitlint/plugins.ts
@@ -16,7 +16,7 @@ export abstract class Plugins {
             bodyStr = Helpers.removeAllCodeBlocks(bodyStr).trim();
 
             if (bodyStr !== "") {
-                function paragraphHasValidEnding(paragraph: string): boolean {
+                let paragraphHasValidEnding = (paragraph: string): boolean => {
                     let paragraphWords = paragraph.split(" ");
                     let lastWordInParagraph =
                         paragraphWords[paragraphWords.length - 1];
@@ -43,7 +43,7 @@ export abstract class Plugins {
                         return true;
                     }
                     return false;
-                }
+                };
 
                 for (let paragraph of Helpers.splitByEOLs(bodyStr, 2)) {
                     paragraph = paragraph.trim();

--- a/commitlint/testHelpers.ts
+++ b/commitlint/testHelpers.ts
@@ -1,0 +1,5 @@
+const { spawnSync } = require("child_process");
+
+export function runCommitLintOnMsg(inputMsg: string) {
+    return spawnSync("npx", ["commitlint", "--verbose"], { input: inputMsg });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "lib": ["ES2021"],
+        "downlevelIteration": true
+    }
+}


### PR DESCRIPTION
Add "compile typescript" step to CI so that any compiler errors in tests are reported rather than lead to test failure with unclear cause.