### PR TITLE
package.json,CI.yml: add devDependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,10 +94,10 @@ jobs:
         run: |
           npm install conventional-changelog-conventionalcommits
           npm install commitlint@latest
-      - name: Install yarn
+      - name: Install yarn & packages
         run: |
           npm install --global yarn
-          yarn add --dev jest typescript ts-jest @types/jest
+          yarn install
       - name: Print versions
         run: |
           git --version
@@ -130,10 +130,10 @@ jobs:
         run: |
           npm install conventional-changelog-conventionalcommits
           npm install commitlint@latest
-      - name: Install yarn
+      - name: Install yarn & packages
         run: |
           npm install --global yarn
-          yarn add --dev jest typescript ts-jest @types/jest ts-node
+          yarn install
       - name: Run typescript compiler
         run: npx tsc
       - name: Print versions

--- a/package.json
+++ b/package.json
@@ -1,5 +1,12 @@
 {
     "dependencies": {
-      "cosmiconfig": "8.0.0"
+        "cosmiconfig": "8.0.0"
+    },
+    "devDependencies": {
+        "@types/jest": "^29.5.11",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
     }
 }


### PR DESCRIPTION
These are packages that are only needed for local development and testing and adding them will make it easier to develop your application. They are not required when your application is deployed in production.