### PR TITLE
CI: configure git inside docker container

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,14 +106,11 @@ jobs:
     needs: build-ts
     # TODO: upgrade to 24.04->24.04 (because LTS) as soon as it's available, instead of 22.04->23.10
     runs-on: ubuntu-22.04
-    container:
-      image: "ubuntu:23.10"
     steps:
       - uses: actions/checkout@v4
       - name: Install required dependencies
         run: |
-          apt update
-          apt install --yes sudo
+          sudo apt update
           sudo apt install --yes --no-install-recommends git ca-certificates
 
           sudo apt install --yes --no-install-recommends npm curl
@@ -124,7 +121,9 @@ jobs:
       - name: Install commitlint dependencies
         run: npm install --verbose @commitlint/types
       - name: Run typescript compiler
-        run: npx tsc
+        run: |
+          npx tsc
+          rm commitlint.config.js
       - name: Print versions
         run: |
           git --version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,7 +92,7 @@ jobs:
           npm install --verboase --global yarn
           yarn add --dev jest typescript ts-jest @types/jest
       - name: Install commitlint dependencies
-        run: npm install --verbose @commitlint/types@18.6.1
+        run: npm install --verbose @commitlint/types
       - name: Print versions
         run: |
           git --version
@@ -122,7 +122,7 @@ jobs:
           npm install --verbose --global yarn
           yarn add --dev jest typescript ts-jest @types/jest ts-node
       - name: Install commitlint dependencies
-        run: npm install --verbose @commitlint/types@18.6.1
+        run: npm install --verbose @commitlint/types
       - name: Run typescript compiler
         run: npx tsc
       - name: Print versions

--- a/commitlint.sh
+++ b/commitlint.sh
@@ -4,6 +4,6 @@ set -euxo pipefail
 # cd to directory of this script
 cd "$(dirname "$0")"
 npm install --verbose
-npm install --verbose @commitlint/config-conventional@18.6.1
+npm install --verbose @commitlint/config-conventional
 npx commitlint --version
 npx commitlint $@


### PR DESCRIPTION
Commitlint fails to execute because a Git error is occurring and it cannot recognize the Git repository:

```
Error: fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

After investigating, I found out that when we run the commitlint plugins tests job on a Docker container, there’s no `.git` directory at all.

Also, when `tsc` is executed, `commitlint.config.js` will be created and commitlint mistakenly reads that file instead of `commitlint.config.ts`. It is always better to use tsconfig `outDir` flag to prevent this issues.