### PR TITLE
commitlint: honor our own WorkflowGuidelines

### DIFF
--- a/commitlint/helpers.ts
+++ b/commitlint/helpers.ts
@@ -20,11 +20,8 @@ export abstract class Helpers {
         potentialString: any,
         paramName: string
     ): string | null {
-        if (potentialString === null || potentialString === undefined) {
-            // otherwise, String(null) might give us the stupid string "null"
-            return null;
-        }
-        return String(potentialString);
+        // this null/undefined check is required, otherwise, String(null) might give us the stupid string "null"
+        return potentialString ? String(potentialString) : null;
     }
 
     public static assertNotNull(

--- a/docs/WorkflowGuidelines.md
+++ b/docs/WorkflowGuidelines.md
@@ -163,9 +163,26 @@
         make use of the type system whenever you can, for example:
 
         * Do not use edge-values to denote absence of value. Example: use null (`Nullable<DateTime>`) instead of `DateTime.MinValue`.
+        * Use Option types instead of Nullable ones if your language provides it (e.g. if you're using F# instead of C#).
         * Do not use `undefined` which is a pitfall from JavaScript (the fact that it has two kinds of null values is a defect in
         its design). As we're using TypeScript we should be able to avoid the uglyness of JavaScript.
-        * Use Option types instead of Nullable ones if your language provides it (e.g. if you're using F# instead of C#).
+
+        Example (with bad practice):
+        ```typescript
+        if (foo === undefined || foo === null)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1;
+        }
+        ```
+
+        Improved code:
+        ```typescript
+        return foo ? 1 : 0;
+        ```
      
     * Abusing obscure operators or the excessive multi-facetedness of basic ones:
  


### PR DESCRIPTION
The workflow guidelines state that we should avoid the keyword "undefined". This is also extra good because it seems that the ? guards against both null and undefined, at least according to this example:

https://github.com/conventional-changelog/commitlint/commit/7ab4bab31f4b19ddedd850e435398037437007b6