### PR TITLE
scripts: fix unpinnedNugetPackage... script

### DIFF
--- a/scripts/unpinnedNugetPackageReferenceVersionsInProjects.fsx
+++ b/scripts/unpinnedNugetPackageReferenceVersionsInProjects.fsx
@@ -9,10 +9,13 @@ open System.IO
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
+
+let targetDir = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let invalidFiles =
     Helpers.GetInvalidFiles
-        rootDir
+        targetDir
         "*.*proj"
         FileConventions.DetectAsteriskInPackageReferenceItems
 


### PR DESCRIPTION
Use working dir instead of script's parent directory in unpinnedNugetPackageReferenceVersionsInProjects.fsx to search for projects as it is intended behavior.