### PR TITLE
FileConventions: account for .env prefix when checking versions in yaml files

### DIFF
--- a/src/FileConventions.Test/DummyFiles/DummyWorkflowsWithEnvPrefixed/DummyCIWithPulumiVersionInEnvPrefixedV2.0.0.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyWorkflowsWithEnvPrefixed/DummyCIWithPulumiVersionInEnvPrefixedV2.0.0.yml
@@ -1,0 +1,17 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+env:
+  PULUMI_VERSION: 2.0.0
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        with:
+          pulumi-version: ${{ env.PULUMI_VERSION }}
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyWorkflowsWithEnvPrefixed/DummyCIWithPulumiVersionInEnvPrefixedV2.0.1.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyWorkflowsWithEnvPrefixed/DummyCIWithPulumiVersionInEnvPrefixedV2.0.1.yml
@@ -1,0 +1,17 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+env:
+  PULUMI_VERSION: 2.0.1
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        with:
+          pulumi-version: ${{ env.PULUMI_VERSION }}
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -430,6 +430,18 @@ let DetectInconsistentVersionsInGitHubCI2() =
     Assert.That(DetectInconsistentVersionsInGitHubCI fileInfo, Is.EqualTo true)
 
 [<Test>]
+let DetectInconsistentVersionsInGitHubCI3() =
+    let fileInfo =
+        DirectoryInfo(
+            Path.Combine(
+                dummyFilesDirectory.FullName,
+                "DummyWorkflowsWithEnvPrefixed"
+            )
+        )
+
+    Assert.That(DetectInconsistentVersionsInGitHubCI fileInfo, Is.EqualTo true)
+
+[<Test>]
 let DetectInconsistentVersionsInNugetRefsInFSharpScripts1() =
     let fileInfos =
         (seq {

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -337,8 +337,14 @@ let private DetectInconsistentVersionsInYamlFiles
                                     yamlDict.Children.["env"]
                                     :?> YamlMappingNode
 
-                                let envVarName =
+                                let referenceString =
                                     variableRegexMatch.Groups.[1].Value
+
+                                let envVarName =
+                                    if referenceString.StartsWith "env." then
+                                        referenceString.[4..]
+                                    else
+                                        referenceString
 
                                 match envDict.Children.TryGetValue envVarName
                                     with


### PR DESCRIPTION
When chceking versions in yaml files, correctly process case when environment variable is referenced using `env.` prefix, e.g. `env.FOO`.