### PR TITLE
scripts: include *.sh files in executable check

### DIFF
--- a/scripts/executableConvention.fsx
+++ b/scripts/executableConvention.fsx
@@ -14,10 +14,13 @@ let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
 let targetDir = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let invalidFiles =
-    Helpers.GetInvalidFiles
-        targetDir
-        "*.fsx"
-        (fun fileInfo -> not(FileConventions.IsExecutable fileInfo))
+    let filter fileInfo =
+        not(FileConventions.IsExecutable fileInfo)
+
+    [ "*.fsx"; "*.sh" ]
+    |> Seq.collect(fun pattern ->
+        Helpers.GetInvalidFiles targetDir pattern filter
+    )
 
 Helpers.AssertNoInvalidFiles
     invalidFiles

--- a/scripts/executableConvention.fsx
+++ b/scripts/executableConvention.fsx
@@ -9,10 +9,13 @@ open System.IO
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
+
+let targetDir = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let invalidFiles =
     Helpers.GetInvalidFiles
-        rootDir
+        targetDir
         "*.fsx"
         (fun fileInfo -> not(FileConventions.IsExecutable fileInfo))
 


### PR DESCRIPTION
Include *.sh files in executable permission check script. Also Use working dir instead of script's parent directory in that script.