### PR TITLE
GithubCI: use Ubuntu 24.04 instead of 23.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,13 +9,16 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+# As we use .NET 8 now, to run tools compiled for .NET 6 we need to set roll-forward to major
+env:
+  DOTNET_ROLL_FORWARD: Major
+
 jobs:
   build-fs:
     name: Build F#
-    # TODO: upgrade to 24.04->24.04 (because LTS) as soon as it's available, instead of 22.04->23.10
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
-      image: "ubuntu:23.10"
+      image: "ubuntu:24.04"
     steps:
       - uses: actions/checkout@v4
       - name: Install required dependencies
@@ -32,7 +35,7 @@ jobs:
           # The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot
           apt install --yes --no-install-recommends ca-certificates
 
-          apt install --yes --no-install-recommends dotnet6
+          apt install --yes --no-install-recommends dotnet-sdk-8.0
 
       - name: Compile the conventions solution
         run: dotnet build --configuration Release conventions.sln
@@ -42,10 +45,9 @@ jobs:
   file-conventions-tests:
     name: Run FileConventions-lib unit tests
     needs: build-fs
-    # TODO: upgrade to 24.04->24.04 (because LTS) as soon as it's available, instead of 22.04->23.10
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
-      image: "ubuntu:23.10"
+      image: "ubuntu:24.04"
     steps:
       - uses: actions/checkout@v4
       - name: Install required dependencies
@@ -61,7 +63,7 @@ jobs:
           # The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot
           apt install --yes --no-install-recommends ca-certificates
 
-          apt install --yes --no-install-recommends dotnet6
+          apt install --yes --no-install-recommends dotnet-sdk-8.0
 
       - name: Run tests to validate F# scripts
         run: dotnet test src/FileConventions.Test/FileConventions.Test.fsproj
@@ -69,10 +71,9 @@ jobs:
   build-ts:
     name: Build TypeScript
 
-    # TODO: upgrade to 24.04->24.04 (because LTS) as soon as it's available, instead of 22.04->23.10
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
-      image: "ubuntu:23.10"
+      image: "ubuntu:24.04"
     steps:
       - uses: actions/checkout@v4
       - name: Install required dependencies
@@ -106,10 +107,9 @@ jobs:
   commitlint-plugins-tests:
     name: Run commitlint-related tests
     needs: build-ts
-    # TODO: upgrade to 24.04->24.04 (because LTS) as soon as it's available, instead of 22.04->23.10
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
-      image: "ubuntu:23.10"
+      image: "ubuntu:24.04"
     steps:
       - uses: actions/checkout@v4
       - name: Install required dependencies
@@ -149,10 +149,9 @@ jobs:
     needs:
       - file-conventions-tests
       - commitlint-plugins-tests
-    # TODO: upgrade to 24.04->24.04 (because LTS) as soon as it's available, instead of 22.04->23.10
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
-      image: "ubuntu:23.10"
+      image: "ubuntu:24.04"
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -193,7 +192,7 @@ jobs:
           # The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot
           apt install --yes --no-install-recommends ca-certificates
 
-          apt install --yes --no-install-recommends dotnet6
+          apt install --yes --no-install-recommends dotnet-sdk-8.0
 
       - name: Check all files end with EOL
         run: dotnet fsi scripts/eofConvention.fsx
@@ -245,6 +244,7 @@ jobs:
         run: |
           dotnet new tool-manifest
           dotnet tool install dotnet-fsharplint --version 0.23.7--date20240109-1215.git-a263185
+          dotnet build conventions.sln
           dotnet dotnet-fsharplint lint conventions.sln
       - name: fantomless
         run: |


### PR DESCRIPTION
Because 23.10 is no longer supported and 24.04 is LTS release.