### PR TITLE
scripts,FileConventions: allow specifying dirs

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,8 @@ This is a repository that contains several useful things that other `nblockchain
     * Use of inconsistent versions:
         * [Use of inconsistent version numbers in `uses:` and `with:` GitHubCI tags](scripts/inconsistentVersionsInGitHubCI.fsx).
         * [Use of inconsistent version numbers in `#r "nuget: ` refs of F# scripts](scripts/inconsistentVersionsInFSharpScripts.fsx).
-        * [Use of inconsistent version numbers in nuget packages of .NET projects](scripts/sanityCheckNuget.fsx).
+        * [Use of inconsistent version numbers in nuget packages of .NET projects](scripts/inconsistentNugetVersionsInDotNetProjects.fsx).
+        * [Use of inconsistent version numbers in nuget packages of .NET projects and `#r "nuget: ` refs of F# scripts](scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx).
 
 All in all, this is mainly documentation, and some tooling to detect bad practices.
 

--- a/src/FileConventions/CombinedVersionCheck.fs
+++ b/src/FileConventions/CombinedVersionCheck.fs
@@ -23,3 +23,16 @@ let DetectInconsistentVersionsInNugetRefsInFSharpScripts
         fsxFileInfos
         projectFileInfos
     |> Map.exists(fun _ versions -> versions.Count > 1)
+
+let GetFsxAndProjectFilesForDirectories(directories: #seq<DirectoryInfo>) =
+    directories
+    |> Seq.fold
+        (fun (fsxFiles, projectFiles) dir ->
+            (Seq.append fsxFiles (Helpers.GetFiles dir "*.fsx")),
+            (Seq.append
+                projectFiles
+                (NugetVersionsCheck.FindProjectFiles(
+                    NugetVersionsCheck.Folder dir
+                )))
+        )
+        (Seq.empty, Seq.empty)


### PR DESCRIPTION
To search for .fsx and project files in combined versions check script. If no arguments are passed, current working directory is used.