### PR TITLE
FileConventions: fix WrapText function

### DIFF
--- a/src/FileConventions.Test/WrapTextTests.fs
+++ b/src/FileConventions.Test/WrapTextTests.fs
@@ -107,3 +107,25 @@ let WrapTextTest5() =
     let expectedResult = text
 
     Assert.That(WrapText text characterCount, Is.EqualTo expectedResult)
+
+[<Test>]
+let WrapTextTest6() =
+    let characterCount = 64
+
+    let commitMsg =
+        "foo: this is a header"
+        + Environment.NewLine
+        + Environment.NewLine
+        + "This is a body:"
+        + Environment.NewLine
+        + Environment.NewLine
+        + "```"
+        + Environment.NewLine
+        + "A code block that has two conditions, it has a very long line that exceeds the limit."
+        + Environment.NewLine
+        + Environment.NewLine
+        + "It also has multiple paragraphs."
+        + Environment.NewLine
+        + "```"
+
+    Assert.That(WrapText commitMsg characterCount, Is.EqualTo commitMsg)

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -261,11 +261,74 @@ let private WrapParagraph (text: string) (maxCharsPerLine: int) : string =
 
     processWords String.Empty String.Empty words
 
-let WrapText (text: string) (maxCharsPerLine: int) : string =
-    let twoEolsToSeparateParagraphs = 2u
+// This function will extract paragraphs and will ignore the paragraphs inside a
+// code block. Each paragraph is determined by two consecutive new lines.
+let ExtractParagraphs(text: string) =
+    let lines = text.Split Environment.NewLine |> Seq.toList
+    let codeBlockStartOrEndToken = "```"
 
+    let rec processLines
+        (remainingLines: List<string>)
+        (currentParagraph: List<string>)
+        (paragraphs: List<string>)
+        (insideCodeBlock: bool)
+        =
+        // process each line individually and form paragraphs
+        match remainingLines with
+        | [] ->
+            if not currentParagraph.IsEmpty then
+                String.Join(Environment.NewLine, List.rev currentParagraph)
+                :: paragraphs
+            else
+                paragraphs
+        | line :: rest ->
+            if String.IsNullOrWhiteSpace line then
+                // a new paragraph has been detected, if it's inside code block
+                // add to the previous paragraph. Otherwise, join the previous
+                // paragraph to a string and start a new paragraph
+                if insideCodeBlock then
+                    processLines
+                        rest
+                        (line :: currentParagraph)
+                        paragraphs
+                        insideCodeBlock
+                elif not currentParagraph.IsEmpty then
+                    let newParagraph =
+                        String.Join(
+                            Environment.NewLine,
+                            List.rev currentParagraph
+                        )
+
+                    processLines
+                        rest
+                        List.Empty
+                        (newParagraph :: paragraphs)
+                        insideCodeBlock
+                else
+                    processLines rest List.Empty paragraphs insideCodeBlock
+            elif line.Trim().StartsWith codeBlockStartOrEndToken then
+                // start or end of a code block has been detected, the line will
+                // be added to the current paragraph and the state which determines
+                // if we're inside a code block or not is switched.
+                let newInsideCodeBlock = not insideCodeBlock
+
+                processLines
+                    rest
+                    (line :: currentParagraph)
+                    paragraphs
+                    newInsideCodeBlock
+            else
+                processLines
+                    rest
+                    (line :: currentParagraph)
+                    paragraphs
+                    insideCodeBlock
+
+    List.rev <| processLines lines List.Empty List.Empty false
+
+let WrapText (text: string) (maxCharsPerLine: int) : string =
     let wrappedParagraphs =
-        SplitByEOLs text twoEolsToSeparateParagraphs
+        ExtractParagraphs text
         |> Seq.map(fun paragraph -> WrapParagraph paragraph maxCharsPerLine)
 
     String.Join(

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -269,15 +269,15 @@ let ExtractParagraphs(text: string) =
 
     let rec processLines
         (remainingLines: List<string>)
-        (currentParagraph: List<string>)
+        (currentParagraphLines: List<string>)
         (paragraphs: List<string>)
         (insideCodeBlock: bool)
         =
         // process each line individually and form paragraphs
         match remainingLines with
         | [] ->
-            if not currentParagraph.IsEmpty then
-                String.Join(Environment.NewLine, List.rev currentParagraph)
+            if not currentParagraphLines.IsEmpty then
+                String.Join(Environment.NewLine, List.rev currentParagraphLines)
                 :: paragraphs
             else
                 paragraphs
@@ -289,14 +289,14 @@ let ExtractParagraphs(text: string) =
                 if insideCodeBlock then
                     processLines
                         rest
-                        (line :: currentParagraph)
+                        (line :: currentParagraphLines)
                         paragraphs
                         insideCodeBlock
-                elif not currentParagraph.IsEmpty then
+                elif not currentParagraphLines.IsEmpty then
                     let newParagraph =
                         String.Join(
                             Environment.NewLine,
-                            List.rev currentParagraph
+                            List.rev currentParagraphLines
                         )
 
                     processLines
@@ -314,13 +314,13 @@ let ExtractParagraphs(text: string) =
 
                 processLines
                     rest
-                    (line :: currentParagraph)
+                    (line :: currentParagraphLines)
                     paragraphs
                     newInsideCodeBlock
             else
                 processLines
                     rest
-                    (line :: currentParagraph)
+                    (line :: currentParagraphLines)
                     paragraphs
                     insideCodeBlock
 


### PR DESCRIPTION
Ignore codeblocks while splitting the text into paragraphs because there might be a codeblock with multiple paragraphs.

Fixes https://github.com/nblockchain/conventions/issues/117

Supersedes https://github.com/nblockchain/conventions/pull/135