### PR TITLE
scripts: exclude files in conventions repository

### DIFF
--- a/scripts/inconsistentNugetVersionsInFSharpScripts.fsx
+++ b/scripts/inconsistentNugetVersionsInFSharpScripts.fsx
@@ -16,6 +16,10 @@ let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let inconsistentVersionsInFsharpScripts =
     Helpers.GetFiles targetDir "*.fsx"
+    |> Seq.filter(fun file ->
+        targetDir = rootDir
+        || not(file.Directory.FullName.StartsWith rootDir.FullName)
+    )
     |> FileConventions.DetectInconsistentVersionsInNugetRefsInFSharpScripts
 
 if inconsistentVersionsInFsharpScripts then


### PR DESCRIPTION
When checking for inconsistent versions of Nuget packages in fsx scripts, because it might produce false positives if conventions repository is inside working directory.