### PR TITLE
FileConventions(Test),scripts: take .env file into account

### DIFF
--- a/scripts/inconsistentVersionsInGitHubCI.fsx
+++ b/scripts/inconsistentVersionsInGitHubCI.fsx
@@ -33,7 +33,7 @@ let targetDir =
         |> fst
 
 let inconsistentVersionsInGitHubCI =
-    FileConventions.DetectInconsistentVersionsInGitHubCI targetDir
+    FileConventions.DetectInconsistentVersionsInGitHubCI targetDir Map.empty
 
 if inconsistentVersionsInGitHubCI then
     failwith

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithSameSetupPulumiVersionInEnv.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithSameSetupPulumiVersionInEnv.yml
@@ -1,0 +1,25 @@
+﻿name: CI
+
+on: [push, pull_request]
+
+jobs:
+  jobA:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: ${{ env.PULUMI_VERSION }}
+      - name: Print "Hello World!"
+        run: echo "Hello World!"
+  jobB:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Pulumi CLI
+        uses: pulumi/setup-pulumi@v2.0.0
+        with:
+          pulumi-version: 3.40.0
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -289,7 +289,7 @@ let DetectInconsistentVersionsInGitHubCIWorkflow1() =
         ))
 
     Assert.That(
-        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo Map.empty,
         Is.EqualTo false
     )
 
@@ -307,7 +307,7 @@ let DetectInconsistentVersionsInGitHubCIWorkflow2() =
         ))
 
     Assert.That(
-        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo Map.empty,
         Is.EqualTo true
     )
 
@@ -325,7 +325,7 @@ let DetectInconsistentVersionsInGitHubCIWorkflow3() =
         ))
 
     Assert.That(
-        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo Map.empty,
         Is.EqualTo true
     )
 
@@ -343,7 +343,7 @@ let DetectInconsistentVersionsInGitHubCIWorkflow4() =
         ))
 
     Assert.That(
-        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo Map.empty,
         Is.EqualTo false
     )
 
@@ -370,7 +370,7 @@ let DetectInconsistentVersionsInGitHubCIWorkflow5() =
         })
 
     Assert.That(
-        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo Map.empty,
         Is.EqualTo true
     )
 
@@ -388,7 +388,7 @@ let DetectInconsistentVersionsInGitHubCIWorkflow6() =
         ))
 
     Assert.That(
-        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo Map.empty,
         Is.EqualTo true
     )
 
@@ -406,7 +406,7 @@ let DetectInconsistentVersionsInGitHubCIWorkflow7() =
         ))
 
     Assert.That(
-        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo,
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo Map.empty,
         Is.EqualTo true
     )
 
@@ -418,7 +418,10 @@ let DetectInconsistentVersionsInGitHubCI1() =
             Path.Combine(dummyFilesDirectory.FullName, "DummyWorkflows")
         )
 
-    Assert.That(DetectInconsistentVersionsInGitHubCI fileInfo, Is.EqualTo true)
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCI fileInfo Map.empty,
+        Is.EqualTo true
+    )
 
 [<Test>]
 let DetectInconsistentVersionsInGitHubCI2() =
@@ -427,7 +430,10 @@ let DetectInconsistentVersionsInGitHubCI2() =
             Path.Combine(dummyFilesDirectory.FullName, "DummyWorkflowsWithEnv")
         )
 
-    Assert.That(DetectInconsistentVersionsInGitHubCI fileInfo, Is.EqualTo true)
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCI fileInfo Map.empty,
+        Is.EqualTo true
+    )
 
 [<Test>]
 let DetectInconsistentVersionsInGitHubCI3() =
@@ -439,7 +445,10 @@ let DetectInconsistentVersionsInGitHubCI3() =
             )
         )
 
-    Assert.That(DetectInconsistentVersionsInGitHubCI fileInfo, Is.EqualTo true)
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCI fileInfo Map.empty,
+        Is.EqualTo true
+    )
 
 [<Test>]
 let DetectInconsistentVersionsInNugetRefsInFSharpScripts1() =

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -410,6 +410,25 @@ let DetectInconsistentVersionsInGitHubCIWorkflow7() =
         Is.EqualTo true
     )
 
+[<Test>]
+let DetectInconsistentVersionsInGitHubCIWorkflow8() =
+    let fileInfo =
+        (Seq.singleton(
+            FileInfo(
+                Path.Combine(
+                    dummyFilesDirectory.FullName,
+                    "DummyCIWithSameSetupPulumiVersionInEnv.yml"
+                )
+            )
+        ))
+
+    let envDict = Map.ofList [ "PULUMI_VERSION", "3.40.0" ]
+
+    Assert.That(
+        DetectInconsistentVersionsInGitHubCIWorkflow fileInfo envDict,
+        Is.EqualTo false
+    )
+
 
 [<Test>]
 let DetectInconsistentVersionsInGitHubCI1() =

--- a/src/FileConventions.Test/FileConventions.Test.fsproj
+++ b/src/FileConventions.Test/FileConventions.Test.fsproj
@@ -48,5 +48,6 @@
     <None Include="DummyFiles\DummyCIWithSameSetupPulumiVersion.yml" />
     <None Include="DummyFiles\DummyCIWithSetupPulumiVersionV2.0.0.yml" />
     <None Include="DummyFiles\DummyCIWithSetupPulumiVersionV2.0.1.yml" />
+    <None Include="DummyFiles\DummyCIWithSameSetupPulumiVersionInEnv.yml" />
   </ItemGroup>
 </Project>

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -362,6 +362,7 @@ let private GetVersionsMapFromFiles
 let private DetectInconsistentVersionsInYamlFiles
     (fileInfos: seq<FileInfo>)
     (extractVersionsFunction: YamlNode -> seq<string * string>)
+    (_globalEnv: Map<string, string>)
     =
     let envVarRegex =
         Regex(@"\s*\$\{\{\s*([^\s\}]+)\s*\}\}\s*", RegexOptions.Compiled)
@@ -426,7 +427,10 @@ let private DetectInconsistentVersionsInYamlFiles
     |> Seq.map(fun item -> Seq.length item.Value > 1)
     |> Seq.contains true
 
-let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
+let DetectInconsistentVersionsInGitHubCIWorkflow
+    (fileInfos: seq<FileInfo>)
+    (globalEnv: Map<string, string>)
+    =
     fileInfos
     |> Seq.iter(fun fileInfo -> assert (fileInfo.FullName.EndsWith ".yml"))
 
@@ -462,15 +466,18 @@ let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
             )
         | _ -> Seq.empty
 
-    DetectInconsistentVersionsInYamlFiles fileInfos extractVersions
+    DetectInconsistentVersionsInYamlFiles fileInfos extractVersions globalEnv
 
-let DetectInconsistentVersionsInGitHubCI(dir: DirectoryInfo) =
+let DetectInconsistentVersionsInGitHubCI
+    (dir: DirectoryInfo)
+    (globalEnv: Map<string, string>)
+    =
     let ymlFiles = dir.GetFiles("*.yml", SearchOption.AllDirectories)
 
     if Seq.isEmpty ymlFiles then
         false
     else
-        DetectInconsistentVersionsInGitHubCIWorkflow ymlFiles
+        DetectInconsistentVersionsInGitHubCIWorkflow ymlFiles globalEnv
 
 let GetVersionsMapForNugetRefsInFSharpScripts(fileInfos: seq<FileInfo>) =
     fileInfos

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -362,7 +362,7 @@ let private GetVersionsMapFromFiles
 let private DetectInconsistentVersionsInYamlFiles
     (fileInfos: seq<FileInfo>)
     (extractVersionsFunction: YamlNode -> seq<string * string>)
-    (_globalEnv: Map<string, string>)
+    (globalEnv: Map<string, string>)
     =
     let envVarRegex =
         Regex(@"\s*\$\{\{\s*([^\s\}]+)\s*\}\}\s*", RegexOptions.Compiled)
@@ -383,6 +383,24 @@ let private DetectInconsistentVersionsInYamlFiles
                 let matches =
                     Seq.collect extractVersionsFunction yamlDoc.AllNodes
 
+                let yamlDict = yamlDoc :?> YamlMappingNode
+
+                let localEnv =
+                    match yamlDict.Children.TryGetValue "env" with
+                    | true, (:? YamlMappingNode as node) -> node
+                    | _ -> YamlMappingNode()
+
+                let envDict =
+                    localEnv.Children
+                    |> Seq.fold
+                        (fun acc pair ->
+                            acc
+                            |> Map.add
+                                (pair.Key :?> YamlScalarNode).Value
+                                (pair.Value :?> YamlScalarNode).Value
+                        )
+                        globalEnv
+
                 matches
                 |> Seq.fold
                     (fun acc (key, value) ->
@@ -390,26 +408,19 @@ let private DetectInconsistentVersionsInYamlFiles
                             let variableRegexMatch = envVarRegex.Match value
 
                             if variableRegexMatch.Success then
-                                let yamlDict = yamlDoc :?> YamlMappingNode
+                                let referenceString =
+                                    variableRegexMatch.Groups.[1].Value
 
-                                match yamlDict.Children.TryGetValue "env" with
-                                | true, (:? YamlMappingNode as envDict) ->
-                                    let referenceString =
-                                        variableRegexMatch.Groups.[1].Value
+                                let envVarName =
+                                    if referenceString.StartsWith "env." then
+                                        referenceString.[4..]
+                                    else
+                                        referenceString
 
-                                    let envVarName =
-                                        if referenceString.StartsWith "env." then
-                                            referenceString.[4..]
-                                        else
-                                            referenceString
-
-                                    match
-                                        envDict.Children.TryGetValue envVarName
-                                        with
-                                    | true, envVarValue ->
-                                        (envVarValue :?> YamlScalarNode).Value
-                                    | false, _ -> value
-                                | _ -> value
+                                match envDict.TryGetValue envVarName with
+                                | true, envVarValue -> envVarValue
+                                | false, _ ->
+                                    failwithf "env. var %s not found" envVarName
                             else
                                 value
 


### PR DESCRIPTION
In inconsistentVersionsInGitHubCI.fsx script when searching for vars referenced in Github workflow files, when .env file is present in the repository root. This is needed because workflows in pulumi-deploy now load vars from .env file.