### PR TITLE
GIthubCI: fix reference to "dynamic uses" action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       image: "ubuntu:24.04"
     steps:
-      - uses: nblockchain/conventions@main
+      - uses: nblockchain/conventions@master
         with:
           uses: actions/checkout@v${{ env.CHECKOUT_ACTION_VERSION }}
       - name: Install required dependencies
@@ -53,7 +53,7 @@ jobs:
     container:
       image: "ubuntu:24.04"
     steps:
-      - uses: nblockchain/conventions@main
+      - uses: nblockchain/conventions@master
         with:
           uses: actions/checkout@v${{ env.CHECKOUT_ACTION_VERSION }}
       - name: Install required dependencies
@@ -81,7 +81,7 @@ jobs:
     container:
       image: "ubuntu:24.04"
     steps:
-      - uses: nblockchain/conventions@main
+      - uses: nblockchain/conventions@master
         with:
           uses: actions/checkout@v${{ env.CHECKOUT_ACTION_VERSION }}
       - name: Install required dependencies
@@ -121,7 +121,7 @@ jobs:
     container:
       image: "ubuntu:24.04"
     steps:
-      - uses: nblockchain/conventions@main
+      - uses: nblockchain/conventions@master
         with:
           uses: actions/checkout@v${{ env.CHECKOUT_ACTION_VERSION }}
       - name: Install required dependencies
@@ -176,7 +176,7 @@ jobs:
           sudo apt install --yes --no-install-recommends git
           # workaround for https://github.com/actions/runner/issues/2033
           git config --global --add safe.directory '*'
-      - uses: nblockchain/conventions@main
+      - uses: nblockchain/conventions@master
         with:
           uses: actions/checkout@v${{ env.CHECKOUT_ACTION_VERSION }}
           with: |


### PR DESCRIPTION
To include the correct branch name (master).

This should have been fixed in [1].

[1] https://github.com/nblockchain/conventions/pull/207