### PR TITLE
scripts/deleteOldArtifacts.fsx: fix JSON provider

### DIFF
--- a/scripts/deleteOldArtifacts.fsx
+++ b/scripts/deleteOldArtifacts.fsx
@@ -56,7 +56,7 @@ type GithubArtifactsType =
   "total_count": 1,
   "artifacts": [
     {
-      "id": 667505922,
+      "id": 4823510038,
       "node_id": "MDg6QXJ0aWZhY3Q2Njc1MDU5MjI=",
       "name": "publishedPackages",
       "size_in_bytes": 151303891,


### PR DESCRIPTION
Change type of artifacts.id to be int64, because its value may not be in int32 range and cause an error like this:
```
System.Exception: Expecting an Int32 at '/artifacts[1]/id', got 4823510038
```