### PR TITLE
fsharplint.json: allow underscores in literals

### DIFF
--- a/fsharplint.json
+++ b/fsharplint.json
@@ -179,7 +179,7 @@
         "enabled": true,
         "config": {
             "naming": "PascalCase",
-            "underscores": "None"
+            "underscores": "AllowInfix"
         }
     },
     "namespaceNames": {


### PR DESCRIPTION
Because pulumi-deploy has some TRAIN_CASE literal names in GreenBlueDeploy project.