### PR TITLE
commitlint.sh: use `source` instead of `.`

### DIFF
--- a/commitlint.sh
+++ b/commitlint.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 # cd to directory of this script
 cd "$(dirname "$0")"
 npm install --verbose
-. ./commitlint/version.config
+source ./commitlint/version.config
 npm install --verbose @commitlint/config-conventional@$COMMITLINT_VERSION
 npx commitlint --version
 npx commitlint $@


### PR DESCRIPTION
The latter is less readable.