### PR TITLE
CI: move checkCommit1by1 to last

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -241,9 +241,6 @@ jobs:
           dotnet tool install fantomless-tool --version 4.7.997-prerelease
           dotnet fantomless --recurse .
           git diff --exit-code
-      - name: Check commits 1 by 1
-        if: github.event_name == 'pull_request'
-        run: dotnet fsi scripts/checkCommits1by1.fsx
 
       - name: Install commitlint&prettier's required dependencies
         run: |
@@ -283,3 +280,7 @@ jobs:
           ./commitlint.sh --verbose \
             --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} \
             --to ${{ github.event.pull_request.head.sha }}
+
+      - name: Check commits 1 by 1
+        if: github.event_name == 'pull_request'
+        run: dotnet fsi scripts/checkCommits1by1.fsx


### PR DESCRIPTION
Before this, if any of steps after this one failed (and there's only one commit in the PR), then it would be a bit confusing because you would see 2 CI failures
in the PR:

- The 'push' event one, which points to the real reason why CI failed.
- The 'pull_request' one, which points you that either you didn't push commits 1 by 1 or there's at least one commit that didn't pass CI.

With this change, now both failures would point to the same error.