### PR TITLE
refactor: move Yml funcs out of Library.fs

### DIFF
--- a/scripts/eofConvention.fsx
+++ b/scripts/eofConvention.fsx
@@ -7,7 +7,7 @@ open System
 #r "nuget: YamlDotNet, Version=16.1.3"
 
 #load "../src/FileConventions/Helpers.fs"
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 
 open type FileConventions.EolAtEof
 

--- a/scripts/executableConvention.fsx
+++ b/scripts/executableConvention.fsx
@@ -5,7 +5,7 @@ open System.IO
 
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo

--- a/scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
+++ b/scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
@@ -10,7 +10,7 @@ open System.IO
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 #load "../src/FileConventions/NugetVersionsCheck.fs"
 #load "../src/FileConventions/CombinedVersionCheck.fs"

--- a/scripts/inconsistentNugetVersionsInFSharpScripts.fsx
+++ b/scripts/inconsistentNugetVersionsInFSharpScripts.fsx
@@ -6,7 +6,7 @@ open System.Linq
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo

--- a/scripts/inconsistentVersionsInGitHubCI.fsx
+++ b/scripts/inconsistentVersionsInGitHubCI.fsx
@@ -5,7 +5,7 @@ open System.IO
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo

--- a/scripts/mixedLineEndings.fsx
+++ b/scripts/mixedLineEndings.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo

--- a/scripts/nonVerboseFlagsInGitHubCIAndScripts.fsx
+++ b/scripts/nonVerboseFlagsInGitHubCIAndScripts.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo

--- a/scripts/shebangConvention.fsx
+++ b/scripts/shebangConvention.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo

--- a/scripts/unpinnedDotnetToolInstallVersions.fsx
+++ b/scripts/unpinnedDotnetToolInstallVersions.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo

--- a/scripts/unpinnedGitHubActionsImageVersions.fsx
+++ b/scripts/unpinnedGitHubActionsImageVersions.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo

--- a/scripts/unpinnedNugetPackageReferenceVersionsInFSharpScripts.fsx
+++ b/scripts/unpinnedNugetPackageReferenceVersionsInFSharpScripts.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo

--- a/scripts/unpinnedNugetPackageReferenceVersionsInProjects.fsx
+++ b/scripts/unpinnedNugetPackageReferenceVersionsInProjects.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo

--- a/scripts/wrapLatestCommitMsg.fsx
+++ b/scripts/wrapLatestCommitMsg.fsx
@@ -6,9 +6,8 @@ open System.Text.RegularExpressions
 open System.Linq
 
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
-#r "nuget: YamlDotNet, Version=16.1.3"
 
-#load "../src/FileConventions/Library.fs"
+#load "../src/FileConventions/FileConventions.fs"
 
 #r "nuget: Fsdk, Version=0.6.0--date20230214-0422.git-1ea6f62"
 

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -9,6 +9,7 @@ open Fsdk
 open Fsdk.Process
 
 open FileConventions
+open Workflow
 
 open type FileConventions.EolAtEof
 

--- a/src/FileConventions/FileConventions.fs
+++ b/src/FileConventions/FileConventions.fs
@@ -5,9 +5,10 @@ open System.IO
 open System.Linq
 open System.Text.RegularExpressions
 
+open Workflow
+
 open Mono
 open Mono.Unix.Native
-open YamlDotNet.RepresentationModel
 
 let SplitByEOLs (text: string) (numberOfEOLs: uint) =
     if numberOfEOLs = 0u then
@@ -358,119 +359,6 @@ let private GetVersionsMapFromFiles
             | None -> Map.add key (Set.singleton value) acc
         )
         Map.empty
-
-let private DetectInconsistentVersionsInYamlFiles
-    (fileInfos: seq<FileInfo>)
-    (extractVersionsFunction: YamlNode -> seq<string * string>)
-    =
-    let envVarRegex =
-        Regex(@"\s*\$\{\{\s*([^\s\}]+)\s*\}\}\s*", RegexOptions.Compiled)
-
-    let yamlDocuments =
-        Seq.map
-            (fun (fileInfo: FileInfo) ->
-                let yaml = YamlStream()
-                use reader = new StreamReader(fileInfo.FullName)
-                yaml.Load reader
-                yaml.Documents[0].RootNode
-            )
-            fileInfos
-
-    let versionMap =
-        Seq.fold
-            (fun mapping (yamlDoc: YamlNode) ->
-                let matches =
-                    Seq.collect extractVersionsFunction yamlDoc.AllNodes
-
-                matches
-                |> Seq.fold
-                    (fun acc (key, value) ->
-                        let actualValue =
-                            let variableRegexMatch = envVarRegex.Match value
-
-                            if variableRegexMatch.Success then
-                                let yamlDict = yamlDoc :?> YamlMappingNode
-
-                                match yamlDict.Children.TryGetValue "env" with
-                                | true, (:? YamlMappingNode as envDict) ->
-                                    let referenceString =
-                                        variableRegexMatch.Groups.[1].Value
-
-                                    let envVarName =
-                                        if referenceString.StartsWith "env." then
-                                            referenceString.[4..]
-                                        else
-                                            referenceString
-
-                                    match
-                                        envDict.Children.TryGetValue envVarName
-                                        with
-                                    | true, envVarValue ->
-                                        (envVarValue :?> YamlScalarNode).Value
-                                    | false, _ -> value
-                                | _ -> value
-                            else
-                                value
-
-                        match Map.tryFind key acc with
-                        | Some prevSet ->
-                            Map.add key (Set.add actualValue prevSet) acc
-                        | None -> Map.add key (Set.singleton actualValue) acc
-                    )
-                    mapping
-            )
-            Map.empty
-            yamlDocuments
-
-    versionMap
-    |> Seq.map(fun item -> Seq.length item.Value > 1)
-    |> Seq.contains true
-
-let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
-    fileInfos
-    |> Seq.iter(fun fileInfo -> assert (fileInfo.FullName.EndsWith ".yml"))
-
-    let extractVersions(node: YamlNode) =
-        match node with
-        | :? YamlMappingNode as yamlDict ->
-            yamlDict.Children
-            |> Seq.collect(fun (KeyValue(keyNode, valueNode)) ->
-                match keyNode, valueNode with
-                | (:? YamlScalarNode as keyScalar),
-                  (:? YamlScalarNode as valueScalar) when
-                    keyScalar.Value = "uses"
-                    ->
-                    match valueScalar.Value.Split "@v" with
-                    | [| name; version |] -> Seq.singleton(name, version)
-                    | _ -> Seq.empty
-                | (:? YamlScalarNode as keyScalar),
-                  (:? YamlMappingNode as valueMapping) when
-                    keyScalar.Value = "with"
-                    ->
-                    valueMapping.Children
-                    |> Seq.choose(fun (KeyValue(innerKeyNode, innerValueNode)) ->
-                        match innerKeyNode, innerValueNode with
-                        | (:? YamlScalarNode as keyScalar),
-                          (:? YamlScalarNode as valueScalar) ->
-                            match keyScalar.Value.Split '-' with
-                            | [| name; "version" |] ->
-                                Some(name, valueScalar.Value)
-                            | _ -> None
-                        | _ -> None
-                    )
-                | _ -> Seq.empty
-            )
-        | _ -> Seq.empty
-
-    DetectInconsistentVersionsInYamlFiles fileInfos extractVersions
-
-let DetectInconsistentVersionsInGitHubCI(dir: DirectoryInfo) =
-    let ymlFiles = dir.GetFiles("*.yml", SearchOption.AllDirectories)
-
-    if Seq.isEmpty ymlFiles then
-        false
-    else
-        DetectInconsistentVersionsInGitHubCIWorkflow ymlFiles
 
 let GetVersionsMapForNugetRefsInFSharpScripts(fileInfos: seq<FileInfo>) =
     fileInfos

--- a/src/FileConventions/FileConventions.fs
+++ b/src/FileConventions/FileConventions.fs
@@ -5,8 +5,6 @@ open System.IO
 open System.Linq
 open System.Text.RegularExpressions
 
-open Workflow
-
 open Mono
 open Mono.Unix.Native
 

--- a/src/FileConventions/FileConventions.fsproj
+++ b/src/FileConventions/FileConventions.fsproj
@@ -7,8 +7,9 @@
 
   <ItemGroup>
     <Compile Include="Helpers.fs" />
+    <Compile Include="Workflow.fs" />
     <Compile Include="NugetVersionsCheck.fs" />
-    <Compile Include="Library.fs" />
+    <Compile Include="FileConventions.fs" />
     <Compile Include="CombinedVersionCheck.fs" />
   </ItemGroup>
 

--- a/src/FileConventions/Workflow.fs
+++ b/src/FileConventions/Workflow.fs
@@ -1,0 +1,119 @@
+module Workflow
+
+open System.IO
+open System.Text.RegularExpressions
+
+open YamlDotNet.RepresentationModel
+
+let private DetectInconsistentVersionsInYamlFiles
+    (fileInfos: seq<FileInfo>)
+    (extractVersionsFunction: YamlNode -> seq<string * string>)
+    =
+    let envVarRegex =
+        Regex(@"\s*\$\{\{\s*([^\s\}]+)\s*\}\}\s*", RegexOptions.Compiled)
+
+    let yamlDocuments =
+        Seq.map
+            (fun (fileInfo: FileInfo) ->
+                let yaml = YamlStream()
+                use reader = new StreamReader(fileInfo.FullName)
+                yaml.Load reader
+                yaml.Documents[0].RootNode
+            )
+            fileInfos
+
+    let versionMap =
+        Seq.fold
+            (fun mapping (yamlDoc: YamlNode) ->
+                let matches =
+                    Seq.collect extractVersionsFunction yamlDoc.AllNodes
+
+                matches
+                |> Seq.fold
+                    (fun acc (key, value) ->
+                        let actualValue =
+                            let variableRegexMatch = envVarRegex.Match value
+
+                            if variableRegexMatch.Success then
+                                let yamlDict = yamlDoc :?> YamlMappingNode
+
+                                match yamlDict.Children.TryGetValue "env" with
+                                | true, (:? YamlMappingNode as envDict) ->
+                                    let referenceString =
+                                        variableRegexMatch.Groups.[1].Value
+
+                                    let envVarName =
+                                        if referenceString.StartsWith "env." then
+                                            referenceString.[4..]
+                                        else
+                                            referenceString
+
+                                    match
+                                        envDict.Children.TryGetValue envVarName
+                                        with
+                                    | true, envVarValue ->
+                                        (envVarValue :?> YamlScalarNode).Value
+                                    | false, _ -> value
+                                | _ -> value
+                            else
+                                value
+
+                        match Map.tryFind key acc with
+                        | Some prevSet ->
+                            Map.add key (Set.add actualValue prevSet) acc
+                        | None -> Map.add key (Set.singleton actualValue) acc
+                    )
+                    mapping
+            )
+            Map.empty
+            yamlDocuments
+
+    versionMap
+    |> Seq.map(fun item -> Seq.length item.Value > 1)
+    |> Seq.contains true
+
+let DetectInconsistentVersionsInGitHubCIWorkflow(fileInfos: seq<FileInfo>) =
+    fileInfos
+    |> Seq.iter(fun fileInfo -> assert (fileInfo.FullName.EndsWith ".yml"))
+
+    let extractVersions(node: YamlNode) =
+        match node with
+        | :? YamlMappingNode as yamlDict ->
+            yamlDict.Children
+            |> Seq.collect(fun (KeyValue(keyNode, valueNode)) ->
+                match keyNode, valueNode with
+                | (:? YamlScalarNode as keyScalar),
+                  (:? YamlScalarNode as valueScalar) when
+                    keyScalar.Value = "uses"
+                    ->
+                    match valueScalar.Value.Split "@v" with
+                    | [| name; version |] -> Seq.singleton(name, version)
+                    | _ -> Seq.empty
+                | (:? YamlScalarNode as keyScalar),
+                  (:? YamlMappingNode as valueMapping) when
+                    keyScalar.Value = "with"
+                    ->
+                    valueMapping.Children
+                    |> Seq.choose(fun (KeyValue(innerKeyNode, innerValueNode)) ->
+                        match innerKeyNode, innerValueNode with
+                        | (:? YamlScalarNode as keyScalar),
+                          (:? YamlScalarNode as valueScalar) ->
+                            match keyScalar.Value.Split '-' with
+                            | [| name; "version" |] ->
+                                Some(name, valueScalar.Value)
+                            | _ -> None
+                        | _ -> None
+                    )
+                | _ -> Seq.empty
+            )
+        | _ -> Seq.empty
+
+    DetectInconsistentVersionsInYamlFiles fileInfos extractVersions
+
+let DetectInconsistentVersionsInGitHubCI(dir: DirectoryInfo) =
+    let ymlFiles = dir.GetFiles("*.yml", SearchOption.AllDirectories)
+
+    if Seq.isEmpty ymlFiles then
+        false
+    else
+        DetectInconsistentVersionsInGitHubCIWorkflow ymlFiles


### PR DESCRIPTION
This way there's no need to ref unnecessary YamlDotNet dep from wrapLatestCommitMsg.fsx script.