### PR TITLE
docs/WorkflowGuidelines.md: remove duplicate rule

### DIFF
--- a/docs/WorkflowGuidelines.md
+++ b/docs/WorkflowGuidelines.md
@@ -181,7 +181,7 @@
         }
         ```
 
-    * Always use curly braces when you can (for readability and diff-noise reduction for upcoming changes):
+    * In languages that have optional braces for `if/else` statements (e.g. C#, TypeScript), we prefer to add them even if the code block will only contain one line. This way, when the next developer adds more lines to it later it's less work for him and doesn't cause unnecessary git-blame noise.
 
         Example (with bad practice):
         ```typescript

--- a/docs/WorkflowGuidelines.md
+++ b/docs/WorkflowGuidelines.md
@@ -12,7 +12,6 @@
 
 * In general, we prefer verbose code (even if it's longer) than short & clever code. This means:
     * We dislike short variable names (if there's some ambiguity on what your variable represents, then choose a longer and more descriptive name).
-    * In languages that have optional braces for `if/else` statements (e.g. C#, TypeScript), we prefer to add them even if the code block will only contain one line. This way, when the next developer adds more lines to it later it's less work for him and doesn't cause unnecessary git-blame noise.
 
 * Group import declarations (e.g. `open` in F# and `using` in C#) in three buckets:
     * The first group for the namespaces that come from the base class libraries.

--- a/docs/WorkflowGuidelines.md
+++ b/docs/WorkflowGuidelines.md
@@ -10,8 +10,7 @@
 
 * Otherwise, PR description could be a summary of all the commits, or choose the most important commit to align with (in case the other commits don't add much substance). In this case, PR has to be merged with "Create a merge commit" button.
 
-* In general, we prefer verbose code (even if it's longer) than short & clever code. This means:
-    * We dislike short variable names (if there's some ambiguity on what your variable represents, then choose a longer and more descriptive name).
+* In general, we prefer verbose code (even if it's longer) than short & clever code. For example, we dislike short variable names (if there's some ambiguity on what your variable represents, then choose a longer and more descriptive name).
 
 * Group import declarations (e.g. `open` in F# and `using` in C#) in three buckets:
     * The first group for the namespaces that come from the base class libraries.


### PR DESCRIPTION
About braces around single statement.

This should have been done in [1].

[1] https://github.com/tarsgate/conventions/pull/238