### PR TITLE
CI: upgrade from ubuntu24.04 to 26.04

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,9 +21,9 @@ env:
 jobs:
   build-fs:
     name: Build F#
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container:
-      image: "ubuntu:24.04"
+      image: "ubuntu:26.04"
     steps:
       - name: Run actions/checkout
         uses: nblockchain/conventions@master
@@ -53,9 +53,9 @@ jobs:
   file-conventions-tests:
     name: Run FileConventions-lib unit tests
     needs: build-fs
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container:
-      image: "ubuntu:24.04"
+      image: "ubuntu:26.04"
     steps:
       - name: Run actions/checkout
         uses: nblockchain/conventions@master
@@ -82,9 +82,9 @@ jobs:
   build-ts:
     name: Build TypeScript
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container:
-      image: "ubuntu:24.04"
+      image: "ubuntu:26.04"
     steps:
       - name: Run actions/checkout
         uses: nblockchain/conventions@master
@@ -124,9 +124,9 @@ jobs:
   commitlint-plugins-tests:
     name: Run commitlint-related tests
     needs: build-ts
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container:
-      image: "ubuntu:24.04"
+      image: "ubuntu:26.04"
     steps:
       - name: Run actions/checkout
         uses: nblockchain/conventions@master
@@ -169,9 +169,9 @@ jobs:
     needs:
       - file-conventions-tests
       - commitlint-plugins-tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     container:
-      image: "ubuntu:24.04"
+      image: "ubuntu:26.04"
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
-  DOTNET_VERSION: "8.0"
+  DOTNET_VERSION: "10.0"
   # As we use .NET>6 now, to run tools compiled for .NETv6 we need to set roll-forward to major
   DOTNET_ROLL_FORWARD: Major
   TYPESCRIPT_VERSION: "5.8.3"

--- a/scripts/unpinnedGitHubActionsImageVersions.fsx
+++ b/scripts/unpinnedGitHubActionsImageVersions.fsx
@@ -18,7 +18,7 @@ let invalidFiles =
         FileConventions.DetectUnpinnedVersionsInGitHubCI
 
 let message =
-    "The following files shouldn't contain `-latest` in `runs-on:` GitHubCI tags."
+    "The following files shouldn't contain `-latest` in `runs-on:` or `container: image:` GitHubCI tags."
     + Environment.NewLine
     + "Here is a list of available runner image versions that you can use:"
     + Environment.NewLine

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithLatestTagButAlsoContainer.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithLatestTagButAlsoContainer.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  file-conventions:
+    runs-on: ubuntu-latest
+    container:
+      image: "ubuntu:26.04"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyCIWithLatestTagOnContainer.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyCIWithLatestTagOnContainer.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  file-conventions:
+    runs-on: ubuntu-24.04
+    container:
+      image: "ubuntu:latest"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print "Hello World!"
+        run: echo "Hello World!"

--- a/src/FileConventions.Test/DummyFiles/DummyGitHubActionWithoutJobs.yml
+++ b/src/FileConventions.Test/DummyFiles/DummyGitHubActionWithoutJobs.yml
@@ -1,0 +1,12 @@
+name: Dynamic Uses
+description: dummy action file (not a workflow)
+inputs:
+  uses:
+    description: Action reference
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Run
+      shell: bash
+      run: echo "Hello"

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -137,6 +137,18 @@ let DetectUnpinnedVersionsInGitHubCI3() =
     Assert.That(DetectUnpinnedVersionsInGitHubCI fileInfo, Is.EqualTo true)
 
 [<Test>]
+let DetectUnpinnedVersionsInGitHubCI4() =
+    let fileInfo =
+        (FileInfo(
+            Path.Combine(
+                dummyFilesDirectory.FullName,
+                "DummyCIWithLatestTagButAlsoContainer.yml"
+            )
+        ))
+
+    Assert.That(DetectUnpinnedVersionsInGitHubCI fileInfo, Is.EqualTo false)
+
+[<Test>]
 let DetectUnpinnedDotnetToolInstallVersions1() =
     let fileInfo =
         (FileInfo(

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -149,6 +149,18 @@ let DetectUnpinnedVersionsInGitHubCI4() =
     Assert.That(DetectUnpinnedVersionsInGitHubCI fileInfo, Is.EqualTo false)
 
 [<Test>]
+let DetectUnpinnedVersionsInGitHubCI5() =
+    let fileInfo =
+        (FileInfo(
+            Path.Combine(
+                dummyFilesDirectory.FullName,
+                "DummyGitHubActionWithoutJobs.yml"
+            )
+        ))
+
+    Assert.That(DetectUnpinnedVersionsInGitHubCI fileInfo, Is.EqualTo false)
+
+[<Test>]
 let DetectUnpinnedDotnetToolInstallVersions1() =
     let fileInfo =
         (FileInfo(

--- a/src/FileConventions.Test/FileConventions.Test.fs
+++ b/src/FileConventions.Test/FileConventions.Test.fs
@@ -124,6 +124,17 @@ let DetectUnpinnedVersionsInGitHubCI2() =
 
     Assert.That(DetectUnpinnedVersionsInGitHubCI fileInfo, Is.EqualTo false)
 
+[<Test>]
+let DetectUnpinnedVersionsInGitHubCI3() =
+    let fileInfo =
+        (FileInfo(
+            Path.Combine(
+                dummyFilesDirectory.FullName,
+                "DummyCIWithLatestTagOnContainer.yml"
+            )
+        ))
+
+    Assert.That(DetectUnpinnedVersionsInGitHubCI fileInfo, Is.EqualTo true)
 
 [<Test>]
 let DetectUnpinnedDotnetToolInstallVersions1() =

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -70,7 +70,10 @@ let DetectUnpinnedVersionsInGitHubCI(fileInfo: FileInfo) =
     let latestTagInRunsOnRegex =
         Regex("runs-on: .*-latest", RegexOptions.Compiled)
 
-    latestTagInRunsOnRegex.IsMatch fileText
+    let latestTagInContainerRegex =
+        Regex("image:\s*\".*:latest\"", RegexOptions.Compiled)
+
+    latestTagInRunsOnRegex.IsMatch fileText || latestTagInContainerRegex.IsMatch fileText
 
 let DetectUnpinnedDotnetToolInstallVersions(fileInfo: FileInfo) =
     assert (fileInfo.FullName.EndsWith(".yml"))

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -77,30 +77,32 @@ let DetectUnpinnedVersionsInGitHubCI(fileInfo: FileInfo) =
     yaml.Load reader
 
     let rootNode = yaml.Documents.[0].RootNode :?> YamlMappingNode
-    let jobsNode = rootNode.Children.["jobs"] :?> YamlMappingNode
 
     let hasUnpinnedRunsOn =
-        jobsNode.Children
-        |> Seq.exists(fun (KeyValue(_, jobNode)) ->
-            let jobMap = jobNode :?> YamlMappingNode
+        match rootNode.Children.TryGetValue "jobs" with
+        | true, (:? YamlMappingNode as jobsNode) ->
+            jobsNode.Children
+            |> Seq.exists(fun (KeyValue(_, jobNode)) ->
+                let jobMap = jobNode :?> YamlMappingNode
 
-            let runsOnLatest =
-                match jobMap.Children.TryGetValue "runs-on" with
-                | true, (:? YamlScalarNode as runsOnNode) ->
-                    runsOnNode.Value.EndsWith "-latest"
-                | _ -> false
+                let runsOnLatest =
+                    match jobMap.Children.TryGetValue "runs-on" with
+                    | true, (:? YamlScalarNode as runsOnNode) ->
+                        runsOnNode.Value.EndsWith "-latest"
+                    | _ -> false
 
-            if not runsOnLatest then
-                false
-            else
-                match jobMap.Children.TryGetValue "container" with
-                | true, (:? YamlMappingNode as containerMap) ->
-                    match containerMap.Children.TryGetValue "image" with
-                    | true, (:? YamlScalarNode as imageNode) ->
-                        imageNode.Value.Contains ":latest"
+                if not runsOnLatest then
+                    false
+                else
+                    match jobMap.Children.TryGetValue "container" with
+                    | true, (:? YamlMappingNode as containerMap) ->
+                        match containerMap.Children.TryGetValue "image" with
+                        | true, (:? YamlScalarNode as imageNode) ->
+                            imageNode.Value.Contains ":latest"
+                        | _ -> true
                     | _ -> true
-                | _ -> true
-        )
+            )
+        | _ -> false
 
     anyContainerWithLatest || hasUnpinnedRunsOn
 

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -67,13 +67,42 @@ let DetectUnpinnedVersionsInGitHubCI(fileInfo: FileInfo) =
 
     let fileText = File.ReadAllText fileInfo.FullName
 
-    let latestTagInRunsOnRegex =
-        Regex("runs-on:\s*.*-latest", RegexOptions.Compiled)
-
     let latestTagInContainerRegex =
         Regex("image:\s*\".*:latest\"", RegexOptions.Compiled)
 
-    latestTagInRunsOnRegex.IsMatch fileText || latestTagInContainerRegex.IsMatch fileText
+    let anyContainerWithLatest = latestTagInContainerRegex.IsMatch fileText
+
+    let yaml = YamlStream()
+    use reader = new StringReader(fileText)
+    yaml.Load reader
+
+    let rootNode = yaml.Documents.[0].RootNode :?> YamlMappingNode
+    let jobsNode = rootNode.Children.["jobs"] :?> YamlMappingNode
+
+    let hasUnpinnedRunsOn =
+        jobsNode.Children
+        |> Seq.exists(fun (KeyValue(_, jobNode)) ->
+            let jobMap = jobNode :?> YamlMappingNode
+
+            let runsOnLatest =
+                match jobMap.Children.TryGetValue "runs-on" with
+                | true, (:? YamlScalarNode as runsOnNode) ->
+                    runsOnNode.Value.EndsWith "-latest"
+                | _ -> false
+
+            if not runsOnLatest then
+                false
+            else
+                match jobMap.Children.TryGetValue "container" with
+                | true, (:? YamlMappingNode as containerMap) ->
+                    match containerMap.Children.TryGetValue "image" with
+                    | true, (:? YamlScalarNode as imageNode) ->
+                        imageNode.Value.Contains ":latest"
+                    | _ -> true
+                | _ -> true
+        )
+
+    anyContainerWithLatest || hasUnpinnedRunsOn
 
 let DetectUnpinnedDotnetToolInstallVersions(fileInfo: FileInfo) =
     assert (fileInfo.FullName.EndsWith(".yml"))

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -68,7 +68,7 @@ let DetectUnpinnedVersionsInGitHubCI(fileInfo: FileInfo) =
     let fileText = File.ReadAllText fileInfo.FullName
 
     let latestTagInRunsOnRegex =
-        Regex("runs-on: .*-latest", RegexOptions.Compiled)
+        Regex("runs-on:\s*.*-latest", RegexOptions.Compiled)
 
     let latestTagInContainerRegex =
         Regex("image:\s*\".*:latest\"", RegexOptions.Compiled)


### PR DESCRIPTION
Reason is that the new version of commitlint (v21.0) now
requires NodeJS v22.x or newer, which is now provided by
the new LTS version of Ubuntu, which we can simply update
to.