### PR TITLE
scripts: improve Usage output

### DIFF
--- a/scripts/gitPush1by1.fsx
+++ b/scripts/gitPush1by1.fsx
@@ -179,7 +179,7 @@ let args = Misc.FsxOnlyArguments()
 
 if args.Length > 3 then
     Console.Error.WriteLine
-        "Usage: gitpush.fsx [remoteName(optional)] [numberOfCommits(optional)]"
+        $"Usage: dotnet fsi {__SOURCE_FILE__} [remoteName(optional)] [numberOfCommits(optional)]"
 
     Environment.Exit 1
 

--- a/scripts/inconsistentNugetVersionsInDotNetProjects.fsx
+++ b/scripts/inconsistentNugetVersionsInDotNetProjects.fsx
@@ -21,7 +21,9 @@ let args = Misc.FsxOnlyArguments()
 let currentDirectory = Directory.GetCurrentDirectory()
 
 if args.Length > 1 then
-    printf "Usage: %s [example.sln(optional)]" __SOURCE_FILE__
+    Console.Error.WriteLine(
+        sprintf "Usage: dotnet fsi %s [example.sln(optional)]" __SOURCE_FILE__
+    )
 
     Environment.Exit 1
 


### PR DESCRIPTION
* Fix outdated script name.
* Include "dotnet fsi" just in case.
* Rather output to StdErr given that exitCode>0.