### PR TITLE
Stop hardcoding commitlint version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,11 +106,7 @@ jobs:
         run: |
           npm install --verbose --global yarn
           yarn add --dev typescript@$TYPESCRIPT_VERSION eslint@$ESLINT_VERSION @eslint/js@$ESLINT_VERSION typescript-eslint@$TYPESCRIPT_ESLINT_VERSION
-      - name: Install commitlint dependencies
-        shell: bash
-        run: |
-          source commitlint/version.config
-          npm install --verbose @commitlint/types@$COMMITLINT_VERSION
+          npm install --verbose
       - name: Print versions
         run: |
           git --version
@@ -143,10 +139,7 @@ jobs:
         run: |
           npm install --verbose --global yarn
           yarn add --dev typescript@$TYPESCRIPT_VERSION ts-node
-      - name: Install commitlint dependencies
-        run: |
-          . commitlint/version.config
-          npm install --verbose @commitlint/types@$COMMITLINT_VERSION
+          npm install --verbose
       - name: Run typescript compiler
         run: npx tsc
       - name: Print versions

--- a/commitlint.sh
+++ b/commitlint.sh
@@ -4,7 +4,5 @@ set -euxo pipefail
 # cd to directory of this script
 cd "$(dirname "$0")"
 npm install --verbose
-source ./commitlint/version.config
-npm install --verbose @commitlint/config-conventional@$COMMITLINT_VERSION
 npx commitlint --version
 npx commitlint $@

--- a/commitlint/version.config
+++ b/commitlint/version.config
@@ -1,1 +1,0 @@
-COMMITLINT_VERSION=latest

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     },
     "devDependencies": {
         "prettier": "2.8.3",
+        "@commitlint/cli": "^21.0.1",
+        "@commitlint/config-conventional": "^21.0.1",
         "@types/node": "^25.2.0",
         "vitest": "^1.3.1",
         "husky": "^9.0.0"


### PR DESCRIPTION
This way you can clone and issue an 'npm install' command and now the build and tests run properly without having to install things manually.