### PR TITLE
scripts,src: update Fsdk(&fsx&fsxc) dependency

### DIFF
--- a/scripts/checkCommits1by1.fsx
+++ b/scripts/checkCommits1by1.fsx
@@ -11,7 +11,7 @@ open System.Text.RegularExpressions
 #r "nuget: FSharp.Data, Version=5.0.2"
 open FSharp.Data
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 
 open Fsdk
 open Fsdk.Process
@@ -1309,7 +1309,7 @@ let ciStatuses =
 
         let hasCiStatus = not(json.Contains "\"check_suites\":[]")
 
-        let checkSuitesParsedJson = CheckSuitesType.Parse json
+        let _checkSuitesParsedJson = CheckSuitesType.Parse json
 
         let shouldHaveCiStatus = ShouldHaveCiStatus commitMsg
 

--- a/scripts/compileFSharpScripts.fsx
+++ b/scripts/compileFSharpScripts.fsx
@@ -3,7 +3,7 @@
 open System
 open System.IO
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 #load "../src/FileConventions/Helpers.fs"
 
 Fsdk
@@ -24,7 +24,9 @@ Fsdk
     .Execute(
         {
             Command = "dotnet"
-            Arguments = sprintf "tool install fsxc --version 0.5.9.1"
+            Arguments =
+                sprintf
+                    "tool install fsxc --version 0.9.99--date20260525-0605.git-a5cfc39"
         },
         Fsdk.Process.Echo.All
     )

--- a/scripts/deleteAssetsFromOldReleases.fsx
+++ b/scripts/deleteAssetsFromOldReleases.fsx
@@ -8,7 +8,7 @@ open System.Net.Http.Headers
 #r "nuget: FSharp.Data, Version=5.0.2"
 open FSharp.Data
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 
 open Fsdk
 open Fsdk.Process

--- a/scripts/deleteOldArtifacts.fsx
+++ b/scripts/deleteOldArtifacts.fsx
@@ -8,7 +8,7 @@ open System.Net.Http.Headers
 #r "nuget: FSharp.Data, Version=5.0.2"
 open FSharp.Data
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 
 open Fsdk
 open Fsdk.Process

--- a/scripts/gitPush1by1.fsx
+++ b/scripts/gitPush1by1.fsx
@@ -8,7 +8,7 @@ open System.Threading
 #r "System.Configuration"
 open System.Configuration
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 
 open Fsdk
 open Fsdk.Process

--- a/scripts/inconsistentNugetVersionsInDotNetProjects.fsx
+++ b/scripts/inconsistentNugetVersionsInDotNetProjects.fsx
@@ -6,11 +6,11 @@ open System.IO
 #r "System.Core.dll"
 #r "System.Xml.Linq.dll"
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 
 open Fsdk
 
-#r "nuget: Microsoft.Build, Version=16.11.0"
+#r "nuget: Microsoft.Build, Version=17.8.43"
 
 #load "../src/FileConventions/Helpers.fs"
 #load "../src/FileConventions/NugetVersionsCheck.fs"

--- a/scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
+++ b/scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
@@ -5,8 +5,8 @@ open System.IO
 #r "System.Core.dll"
 #r "System.Xml.Linq.dll"
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
-#r "nuget: Microsoft.Build, Version=16.11.0"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
+#r "nuget: Microsoft.Build, Version=17.8.43"
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"
 

--- a/scripts/replace.fsx
+++ b/scripts/replace.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "System.Configuration"
 open System.Configuration
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 open Fsdk
 
 let args = Misc.FsxOnlyArguments()

--- a/scripts/runFSharpLint.fsx
+++ b/scripts/runFSharpLint.fsx
@@ -3,7 +3,7 @@
 open System.IO
 open System.Linq
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 
 open Fsdk
 
@@ -17,7 +17,7 @@ let targetSol =
     match args with
     | [] -> None
     | head :: [] -> Some head
-    | head :: tail -> failwithf "Too many arguments: %A" args
+    | _head :: _tail -> failwithf "Too many arguments: %A" args
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
 let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo

--- a/scripts/wrapLatestCommitMsg.fsx
+++ b/scripts/wrapLatestCommitMsg.fsx
@@ -10,7 +10,7 @@ open System.Linq
 
 #load "../src/FileConventions/Library.fs"
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 
 open Fsdk
 open Fsdk.Process
@@ -64,7 +64,8 @@ Fsdk
             Arguments =
                 $"commit --amend --message \"{EscapeDoubleQuotes newCommitMsg}\""
         },
-        Echo.Off
+        Echo.OutputOnly
     )
     .UnwrapDefault()
     .Trim()
+|> ignore<string>

--- a/src/FileConventions.Test/DummyFiles/DummyScriptWithNonVerboseFlag.fsx
+++ b/src/FileConventions.Test/DummyFiles/DummyScriptWithNonVerboseFlag.fsx
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S dotnet fsi
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 
 open Fsdk
 open Fsdk.Process

--- a/src/FileConventions.Test/DummyFiles/DummyScriptWithoutNonVerboseFlag.fsx
+++ b/src/FileConventions.Test/DummyFiles/DummyScriptWithoutNonVerboseFlag.fsx
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S dotnet fsi
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 
 open Fsdk
 open Fsdk.Process

--- a/src/FileConventions.Test/DummyFiles/DummyWithoutMissingVersionsInNugetPackageReferences.fsx
+++ b/src/FileConventions.Test/DummyFiles/DummyWithoutMissingVersionsInNugetPackageReferences.fsx
@@ -3,4 +3,4 @@
 open System.IO
 open System
 
-#r "nuget: Fsdk, Version=0.6.1--date20260403-0728.git-c9a0eae"
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"

--- a/src/FileConventions.Test/FileConventions.Test.fsproj
+++ b/src/FileConventions.Test/FileConventions.Test.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
@@ -19,7 +19,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
-    <PackageReference Include="Fsdk" Version="0.6.1--date20260403-0728.git-c9a0eae" />
+    <PackageReference Include="Fsdk" Version="0.9.99--date20260525-0605.git-a5cfc39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FileConventions/FileConventions.fsproj
+++ b/src/FileConventions/FileConventions.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="16.11.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.8.43" />
     <PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="YamlDotNet" Version="16.1.3" />


### PR DESCRIPTION
In order to fix gitPush1by1.fsx bug about not being able
to get the current branch name; see:

https://github.com/tarsgate/fsx/pull/58

NB: After the bump of fsdk/fsx, it uncovered warnings that were
now being treated as errors.