### PR TITLE
GhActions(pi): allow /pi post EOL too, inside string

### DIFF
--- a/.github/workflows/pi.yml
+++ b/.github/workflows/pi.yml
@@ -11,9 +11,11 @@ permissions:
 
 jobs:
   pi-agent:
+    # HACK: GitHub Actions expressions don't support escape sequences like \n in string literals,
+    # so fromJSON('"\n"') is used to inject an actual newline character
     if: |
       contains(fromJson('["knocte", "webwarrior-ws"]'), github.actor) &&
-      startsWith(github.event.comment.body, '/pi ')
+      (startsWith(github.event.comment.body, '/pi ') || contains(github.event.comment.body, format('{0}/pi ', fromJSON('"\n"'))))
     runs-on: ubuntu-24.04
     steps:
       - name: Setup Node


### PR DESCRIPTION

- Replaced the overly-restrictive `startsWith(github.event.comment.body, '/pi ')` with a condition that only triggers when `/pi ` appears either:
  1. At the very beginning of the comment (`startsWith(...)`), **or**
  2. At the start of a new line (`contains(..., format('{0}/pi ', fromJSON('"\n"'))))`).

- This uses `fromJSON('"\n"')` to inject a proper newline character into the GitHub Actions expression, matching the requirement in #261 to detect `/pi ` after an EOL.

Fixes #261