### PR TITLE
CI,scripts: print more info for shebang check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Check all files end with EOL
         run: dotnet fsi scripts/eofConvention.fsx
-      - name: Check all .fsx scripts have shebang
+      - name: Check all .fsx scripts have (proper) shebang
         run: dotnet fsi scripts/shebangConvention.fsx
       - name: Check all F# scripts have execute permission
         run: dotnet fsi scripts/executableConvention.fsx

--- a/scripts/compileFSharpScripts.fsx
+++ b/scripts/compileFSharpScripts.fsx
@@ -35,8 +35,11 @@ Fsdk
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
 
+printfn "Checking base directory: %s" rootDir.FullName
+
 Helpers.GetFiles rootDir "*.fsx"
 |> Seq.iter(fun fileInfo ->
+    printfn "Checking file: %s" fileInfo.FullName
     Fsdk
         .Process
         .Execute(

--- a/scripts/eofConvention.fsx
+++ b/scripts/eofConvention.fsx
@@ -13,11 +13,14 @@ open type FileConventions.EolAtEof
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
 
+printfn "Checking base directory: %s" rootDir.FullName
+
 let invalidFiles =
-    Helpers.GetInvalidFiles
-        rootDir
-        "*.*"
-        (fun fileInfo -> FileConventions.EolAtEof fileInfo = False)
+    Helpers.GetFiles rootDir "*.*"
+    |> Seq.filter(fun fileInfo ->
+        printfn "Checking file: %s" fileInfo.FullName
+        FileConventions.EolAtEof fileInfo = False
+    )
 
 Helpers.AssertNoInvalidFiles
     invalidFiles

--- a/scripts/executableConvention.fsx
+++ b/scripts/executableConvention.fsx
@@ -13,13 +13,16 @@ let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
 
 let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
+printfn "Checking base directory: %s" targetDir.FullName
+
 let invalidFiles =
     let filter fileInfo =
+        printfn "Checking file: %s" fileInfo.FullName
         not(FileConventions.IsExecutable fileInfo)
 
     [ "*.fsx"; "*.sh" ]
     |> Seq.collect(fun pattern ->
-        Helpers.GetInvalidFiles targetDir pattern filter
+        Helpers.GetFiles targetDir pattern |> Seq.filter filter
     )
 
 Helpers.AssertNoInvalidFiles

--- a/scripts/inconsistentNugetVersionsInDotNetProjects.fsx
+++ b/scripts/inconsistentNugetVersionsInDotNetProjects.fsx
@@ -44,6 +44,10 @@ let target =
                 "'%s' argument is invalid. You should enter an .sln file or run this script on current directory"
                 singleArg
 
+printfn "Checking target: %s"
+    (match target with
+     | ScriptTarget.Folder di -> di.FullName
+     | ScriptTarget.Solution fi -> fi.FullName)
 
 let nugetSolutionPackagesDir =
     Path.Combine(currentDirectory, "packages") |> DirectoryInfo

--- a/scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
+++ b/scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
@@ -33,6 +33,9 @@ let targetDirs =
 
         dirs
 
+for dir in targetDirs do
+    printfn "Checking base directory: %s" dir.FullName
+
 let versionsMap =
     let fsxFiles, projectFiles =
         CombinedVersionCheck.GetFsxAndProjectFilesForDirectories targetDirs

--- a/scripts/inconsistentNugetVersionsInFSharpScripts.fsx
+++ b/scripts/inconsistentNugetVersionsInFSharpScripts.fsx
@@ -14,9 +14,12 @@ let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
 
 let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
+printfn "Checking base directory: %s" targetDir.FullName
+
 let inconsistentVersionsInFsharpScripts =
     Helpers.GetFiles targetDir "*.fsx"
     |> Seq.filter(fun file ->
+        printfn "Checking file: %s" file.FullName
         targetDir = rootDir
         || not(file.Directory.FullName.StartsWith rootDir.FullName)
     )

--- a/scripts/inconsistentVersionsInGitHubCI.fsx
+++ b/scripts/inconsistentVersionsInGitHubCI.fsx
@@ -32,6 +32,8 @@ let targetDir =
             githubWorkflowsDirFromRootDir
         |> fst
 
+printfn "Checking base directory: %s" targetDir.FullName
+
 let inconsistentVersionsInGitHubCI =
     FileConventions.DetectInconsistentVersionsInGitHubCI targetDir
 

--- a/scripts/mixedLineEndings.fsx
+++ b/scripts/mixedLineEndings.fsx
@@ -11,8 +11,14 @@ open System.IO
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
 
+printfn "Checking base directory: %s" rootDir.FullName
+
 let invalidFiles =
-    Helpers.GetInvalidFiles rootDir "*.*" FileConventions.MixedLineEndings
+    Helpers.GetFiles rootDir "*.*"
+    |> Seq.filter(fun fileInfo ->
+        printfn "Checking file: %s" fileInfo.FullName
+        FileConventions.MixedLineEndings fileInfo
+    )
 
 Helpers.AssertNoInvalidFiles
     invalidFiles

--- a/scripts/nonVerboseFlagsInGitHubCIAndScripts.fsx
+++ b/scripts/nonVerboseFlagsInGitHubCIAndScripts.fsx
@@ -11,6 +11,8 @@ open System.IO
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
 
+printfn "Checking base directory: %s" rootDir.FullName
+
 let validExtensions =
     seq {
         ".yml"
@@ -22,10 +24,11 @@ let validExtensions =
 let invalidFiles =
     validExtensions
     |> Seq.collect(fun ext ->
-        Helpers.GetInvalidFiles
-            rootDir
-            ("*" + ext)
-            FileConventions.NonVerboseFlags
+        Helpers.GetFiles rootDir ("*" + ext)
+        |> Seq.filter(fun fileInfo ->
+            printfn "Checking file: %s" fileInfo.FullName
+            FileConventions.NonVerboseFlags fileInfo
+        )
     )
 
 let message = "Please don't use non-verbose flags in the following files:"

--- a/scripts/runFSharpLint.fsx
+++ b/scripts/runFSharpLint.fsx
@@ -25,6 +25,8 @@ let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
 let targetDir, fallbackDir =
     Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
+printfn "Checking base directory: %s" targetDir.FullName
+
 let targetSolution =
     match targetSol with
     | Some solFilename ->
@@ -161,7 +163,12 @@ let allFiles = Fsdk.Misc.GetAllFilesRecursively targetDir |> Seq.map FileInfo
 let fsxFiles =
     allFiles |> Seq.filter(fun filename -> filename.Extension = ".fsx")
 
-let results = fsxFiles |> Seq.map RunFSharpLint
+let results =
+    fsxFiles
+    |> Seq.map(fun file ->
+        printfn "Checking file: %s" file.FullName
+        RunFSharpLint file
+    )
 
 let violationsExist =
     results

--- a/scripts/shebangConvention.fsx
+++ b/scripts/shebangConvention.fsx
@@ -11,11 +11,14 @@ open System.IO
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
 
+printfn "Checking base directory: %s" rootDir.FullName
+
 let invalidFiles =
-    Helpers.GetInvalidFiles
-        rootDir
-        "*.fsx"
-        (fun fileInfo -> not(FileConventions.HasCorrectShebang fileInfo))
+    Helpers.GetFiles rootDir "*.fsx"
+    |> Seq.filter(fun fileInfo ->
+        printfn "Checking file: %s" fileInfo.FullName
+        not(FileConventions.HasCorrectShebang fileInfo)
+    )
 
 Helpers.AssertNoInvalidFiles
     invalidFiles

--- a/scripts/unpinnedDotnetToolInstallVersions.fsx
+++ b/scripts/unpinnedDotnetToolInstallVersions.fsx
@@ -11,11 +11,14 @@ open System.IO
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
 
+printfn "Checking base directory: %s" rootDir.FullName
+
 let invalidFiles =
-    Helpers.GetInvalidFiles
-        rootDir
-        "*.yml"
-        FileConventions.DetectUnpinnedDotnetToolInstallVersions
+    Helpers.GetFiles rootDir "*.yml"
+    |> Seq.filter(fun fileInfo ->
+        printfn "Checking file: %s" fileInfo.FullName
+        FileConventions.DetectUnpinnedDotnetToolInstallVersions fileInfo
+    )
 
 let message =
     "Please define the package version number in the `dotnet tool install` commands."

--- a/scripts/unpinnedGitHubActionsImageVersions.fsx
+++ b/scripts/unpinnedGitHubActionsImageVersions.fsx
@@ -11,11 +11,14 @@ open System.IO
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
 
+printfn "Checking base directory: %s" rootDir.FullName
+
 let invalidFiles =
-    Helpers.GetInvalidFiles
-        rootDir
-        "*.yml"
-        FileConventions.DetectUnpinnedVersionsInGitHubCI
+    Helpers.GetFiles rootDir "*.yml"
+    |> Seq.filter(fun fileInfo ->
+        printfn "Checking file: %s" fileInfo.FullName
+        FileConventions.DetectUnpinnedVersionsInGitHubCI fileInfo
+    )
 
 let message =
     "The following files shouldn't contain `-latest` in `runs-on:` or `container: image:` GitHubCI tags."

--- a/scripts/unpinnedNugetPackageReferenceVersionsInFSharpScripts.fsx
+++ b/scripts/unpinnedNugetPackageReferenceVersionsInFSharpScripts.fsx
@@ -11,11 +11,14 @@ open System.IO
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
 
+printfn "Checking base directory: %s" rootDir.FullName
+
 let invalidFiles =
-    Helpers.GetInvalidFiles
-        rootDir
-        "*.fsx"
-        FileConventions.DetectMissingVersionsInNugetPackageReferences
+    Helpers.GetFiles rootDir "*.fsx"
+    |> Seq.filter(fun fileInfo ->
+        printfn "Checking file: %s" fileInfo.FullName
+        FileConventions.DetectMissingVersionsInNugetPackageReferences fileInfo
+    )
 
 let message =
     "The following files shouldn't miss the version number in `#r \"nuget: ` refs of F# scripts."

--- a/scripts/unpinnedNugetPackageReferenceVersionsInProjects.fsx
+++ b/scripts/unpinnedNugetPackageReferenceVersionsInProjects.fsx
@@ -14,11 +14,14 @@ let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
 
 let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
+printfn "Checking base directory: %s" targetDir.FullName
+
 let invalidFiles =
-    Helpers.GetInvalidFiles
-        targetDir
-        "*.*proj"
-        FileConventions.DetectAsteriskInPackageReferenceItems
+    Helpers.GetFiles targetDir "*.*proj"
+    |> Seq.filter(fun fileInfo ->
+        printfn "Checking file: %s" fileInfo.FullName
+        FileConventions.DetectAsteriskInPackageReferenceItems fileInfo
+    )
 
 let message =
     "The following files shouldn't use asterisk (*) in PackageReference items of .NET projects."


### PR DESCRIPTION
Supersedes #263.

- At the start of execution, `shebangConvention.fsx` now prints the base directory being scanned.
- Before each file check, the script prints the `.fsx` file path so CI logs show clear progress.
- The CI workflow step name retains the `(proper)` addition.