### PR TITLE
fix: cloneWorkTree.fsx always assumes branch does not exist

### DIFF
--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -102,17 +102,42 @@ match worktreeProc.Result with
 // 8) cd into featureBranchName and create branch
 Directory.SetCurrentDirectory featureBranchName
 
+let branchExists =
+    let output =
+        Process
+            .Execute(
+                {
+                    Command = "git"
+                    Arguments = sprintf "branch --list %s" featureBranchName
+                },
+                Echo.Off
+            )
+            .UnwrapDefault()
+            .Trim()
+
+    output.Contains featureBranchName
+
+let checkoutArgs =
+    if branchExists then
+        sprintf "switch %s" featureBranchName
+    else
+        sprintf "checkout -b %s" featureBranchName
+
 let gitCheckout =
     {
         Command = "git"
-        Arguments = sprintf "checkout -b %s" featureBranchName
+        Arguments = checkoutArgs
     }
 
 let checkoutProc = Process.Execute(gitCheckout, Echo.All)
 
 match checkoutProc.Result with
 | Error _ ->
-    Console.Error.WriteLine "Git checkout -b failed."
+    if branchExists then
+        Console.Error.WriteLine("Git switch failed.")
+    else
+        Console.Error.WriteLine("Git checkout -b failed.")
+
     Environment.Exit 5
 | WarningsOrAmbiguous _
 | Success _ -> ()


### PR DESCRIPTION
When the second argument to cloneWorkTree.fsx is a branch that already exists, the script fails because \`git checkout -b\` returns an error if the branch already exists.

This change first checks if the branch already exists, and if so, uses \`git switch\` instead so the existing branch is checked out properly.

Fixes #270