### PR TITLE
fix(cloneWorkTree): support SCP-style SSH URLs like git@host:path/repo.git

### DIFF
--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -24,8 +24,21 @@ let featureBranchName = args.[1]
 
 // 1) Extract repo name from URL
 let repoName =
-    let uri = Uri repoUrl
-    let segments = uri.AbsolutePath.TrimEnd('/').Split('/')
+    let pathPart =
+        if repoUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
+            // SCP-style SSH URL: git@host:path/to/repo.git
+            let colonIndex = repoUrl.IndexOf(':')
+
+            if colonIndex < 0 then
+                failwith "Invalid SCP-style git URL: missing ':' separator"
+
+            repoUrl.Substring(colonIndex + 1)
+        else
+            // Standard URI (https, ssh://, file://, etc.)
+            let uri = Uri repoUrl
+            uri.AbsolutePath
+
+    let segments = pathPart.TrimEnd('/').Split('/')
     let lastSegmentOpt = Array.tryLast segments
 
     match lastSegmentOpt with


### PR DESCRIPTION
Fixes #269.

The script previously used `System.Uri` to parse all repository URLs, which throws `UriFormatException` on SCP-style SSH URLs such as `git@github.com:tarsgate/conventions.git`.

This fix detects SCP-style URLs (strings starting with `git@`) and extracts the path part manually, falling back to `System.Uri` for standard URLs (`https://`, `ssh://`, `file://`, etc.).

**Change summary:**
- Detect `git@` prefix to identify SCP-style SSH URLs
- Extract path after the `:` separator (e.g. `tarsgate/conventions.git`)
- Keep using `System.Uri.AbsolutePath` for all other URL schemes