### PR TITLE
feat: new script called clonePR.fsx

### DIFF
--- a/scripts/clonePR.fsx
+++ b/scripts/clonePR.fsx
@@ -1,0 +1,118 @@
+#!/usr/bin/env -S dotnet fsi
+
+open System
+open System.IO
+open System.Net.Http
+open System.Text.RegularExpressions
+
+#r "System.Configuration"
+open System.Configuration
+
+#r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
+#r "nuget: FSharp.Data, Version=5.0.2"
+
+open FSharp.Data
+open Fsdk
+open Fsdk.Process
+
+let args = Misc.FsxOnlyArguments()
+
+if args.Length <> 1 then
+    Console.Error.WriteLine $"Usage: dotnet fsi {__SOURCE_FILE__} <prUrl>"
+
+    Environment.Exit 1
+
+let prUrl = args.[0]
+
+// Validate and parse PR URL
+// Expected format: https://github.com/<owner>/<repo>/pull/<number>
+let prRegex =
+    Regex(
+        @"^https?://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+)/pull/(?<number>\d+)/?$",
+        RegexOptions.IgnoreCase
+    )
+
+let regexMatch = prRegex.Match prUrl
+
+if not regexMatch.Success then
+    Console.Error.WriteLine
+        "Invalid PR URL. Expected format: https://github.com/<owner>/<repo>/pull/<number>"
+
+    Environment.Exit 2
+
+let owner = regexMatch.Groups.["owner"].Value
+let repo = regexMatch.Groups.["repo"].Value
+let prNumber = regexMatch.Groups.["number"].Value
+
+// Fetch PR details via GitHub API
+let apiUrl = $"https://api.github.com/repos/{owner}/{repo}/pulls/{prNumber}"
+
+let httpClient = new HttpClient()
+
+httpClient.DefaultRequestHeaders.Add("User-Agent", "clonePR.fsx")
+
+let response =
+    try
+        httpClient.GetStringAsync(apiUrl).Result
+    with
+    | ex ->
+        Console.Error.WriteLine(
+            $"Failed to fetch PR data from GitHub API: {ex.Message}"
+        )
+
+        Environment.Exit 3
+        failwith "unreachableAfterApiFailure"
+
+let prJson = JsonValue.Parse response
+
+let headRepoUrl =
+    try
+        prJson
+            .GetProperty("head")
+            .GetProperty("repo")
+            .GetProperty("clone_url")
+            .AsString()
+    with
+    | ex ->
+        Console.Error.WriteLine(
+            $"Failed to extract head repo URL from PR data: {ex.Message}"
+        )
+
+        Environment.Exit 4
+        failwith "unreachableAfterRepoUrlExtractionFailure"
+
+let headBranch =
+    try
+        prJson
+            .GetProperty("head")
+            .GetProperty("ref")
+            .AsString()
+    with
+    | ex ->
+        Console.Error.WriteLine(
+            $"Failed to extract head branch from PR data: {ex.Message}"
+        )
+
+        Environment.Exit 5
+        failwith "unreachableAfterBranchExtractionFailure"
+
+Console.WriteLine $"PR #{prNumber} source repo: {headRepoUrl}"
+Console.WriteLine $"PR #{prNumber} source branch: {headBranch}"
+
+// Call cloneWorkTree.fsx
+let cloneWorkTreeScript =
+    Path.Combine(__SOURCE_DIRECTORY__, "cloneWorkTree.fsx")
+
+let dotnetFsi =
+    {
+        Command = "dotnet"
+        Arguments =
+            $"fsi \"{cloneWorkTreeScript}\" \"{headRepoUrl}\" \"{headBranch}\""
+    }
+
+let proc = Process.Execute(dotnetFsi, Echo.All)
+
+match proc.Result with
+| Error _ -> Environment.Exit 6
+| WarningsOrAmbiguous _
+| Success _ -> ()

--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -15,12 +15,12 @@ let args = Misc.FsxOnlyArguments()
 
 if args.Length <> 2 then
     Console.Error.WriteLine
-        $"Usage: dotnet fsi {__SOURCE_FILE__} <repoUrl> <featureBranchName>"
+        $"Usage: dotnet fsi {__SOURCE_FILE__} <repoUrl> <branchName>"
 
     Environment.Exit 1
 
 let repoUrl = args.[0]
-let featureBranchName = args.[1]
+let branchName = args.[1]
 
 // 1) Extract repo name from URL
 let repoName =
@@ -49,6 +49,22 @@ let repoName =
         else
             lastSegment
 
+let branchExists =
+    let output =
+        Process
+            .Execute(
+                {
+                    Command = "git"
+                    Arguments =
+                        sprintf "ls-remote --heads %s %s" repoUrl branchName
+                },
+                Echo.Off
+            )
+            .UnwrapDefault()
+            .Trim()
+
+    output.Contains branchName
+
 // 2) Create subfolder with same name as repo (fail if already exists)
 if Directory.Exists repoName then
     Console.Error.WriteLine(sprintf "Directory '%s' already exists." repoName)
@@ -59,11 +75,21 @@ Directory.CreateDirectory repoName |> ignore<DirectoryInfo>
 // 3) cd into that folder
 Directory.SetCurrentDirectory repoName
 
+let cloneSpecificSingleBranch =
+    if branchExists then
+        sprintf "--branch %s" branchName
+    else
+        String.Empty
+
 // 4) git clone --single-branch --bare <repository-url> .bare
 let gitClone =
     {
         Command = "git"
-        Arguments = sprintf "clone --single-branch --bare %s .bare" repoUrl
+        Arguments =
+            sprintf
+                "clone --single-branch %s --bare -- %s .bare"
+                cloneSpecificSingleBranch
+                repoUrl
     }
 
 let cloneProc = Process.Execute(gitClone, Echo.All)
@@ -88,19 +114,20 @@ let gitSymbolicRef =
         Arguments = "symbolic-ref HEAD --short"
     }
 
-let defaultBranch =
-    Process
-        .Execute(gitSymbolicRef, Echo.Off)
-        .UnwrapDefault()
-        .Trim()
+let baseBranch =
+    if branchExists then
+        branchName
+    else
+        Process
+            .Execute(gitSymbolicRef, Echo.Off)
+            .UnwrapDefault()
+            .Trim()
 
-Console.WriteLine(sprintf "Default branch: %s" defaultBranch)
-
-// 7) git worktree add <defaultBranch> <featureBranchName>
+// 7) git worktree add <defaultBranch> <branchName>
 let gitWorktreeAdd =
     {
         Command = "git"
-        Arguments = sprintf "worktree add %s %s" featureBranchName defaultBranch
+        Arguments = sprintf "worktree add %s %s" branchName baseBranch
     }
 
 let worktreeProc = Process.Execute(gitWorktreeAdd, Echo.All)
@@ -112,53 +139,35 @@ match worktreeProc.Result with
 | WarningsOrAmbiguous _
 | Success _ -> ()
 
-// 8) cd into featureBranchName and create branch
-Directory.SetCurrentDirectory featureBranchName
+// 8) cd into branchName and create branch
+Directory.SetCurrentDirectory branchName
 
-let branchExists =
-    let output =
-        Process
-            .Execute(
-                {
-                    Command = "git"
-                    Arguments = sprintf "branch --list %s" featureBranchName
-                },
-                Echo.Off
-            )
-            .UnwrapDefault()
-            .Trim()
+if not branchExists then
+    let checkoutArgs = sprintf "checkout -b %s" branchName
 
-    output.Contains featureBranchName
+    let gitCheckout =
+        {
+            Command = "git"
+            Arguments = checkoutArgs
+        }
 
-let checkoutArgs =
-    if branchExists then
-        sprintf "switch %s" featureBranchName
-    else
-        sprintf "checkout -b %s" featureBranchName
+    let checkoutProc = Process.Execute(gitCheckout, Echo.All)
 
-let gitCheckout =
-    {
-        Command = "git"
-        Arguments = checkoutArgs
-    }
+    match checkoutProc.Result with
+    | Error _ ->
+        if branchExists then
+            Console.Error.WriteLine("Git switch failed.")
+        else
+            Console.Error.WriteLine("Git checkout -b failed.")
 
-let checkoutProc = Process.Execute(gitCheckout, Echo.All)
-
-match checkoutProc.Result with
-| Error _ ->
-    if branchExists then
-        Console.Error.WriteLine("Git switch failed.")
-    else
-        Console.Error.WriteLine("Git checkout -b failed.")
-
-    Environment.Exit 5
-| WarningsOrAmbiguous _
-| Success _ -> ()
+        Environment.Exit 5
+    | WarningsOrAmbiguous _
+    | Success _ -> ()
 
 Console.WriteLine(
     sprintf
         "Successfully created worktree '%s' from branch '%s' of repo '%s'"
-        defaultBranch
-        featureBranchName
+        baseBranch
+        branchName
         repoName
 )


### PR DESCRIPTION
Adds a new F# script `scripts/clonePR.fsx` that receives a GitHub PR URL, queries the GitHub API to find the source repository and branch, and then calls `cloneWorkTree.fsx` under the hood with the repo URL and branch name.

Closes #273
