### PR TITLE
feat: cloneWorkTree.fsx should work even if directory where to clone already exists

### DIFF
--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -49,6 +49,34 @@ let repoName =
         else
             lastSegment
 
+let ghOwner =
+    let pathPart =
+        if repoUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
+            let colonIndex = repoUrl.IndexOf ':'
+            repoUrl.Substring(colonIndex + 1)
+        else
+            (Uri repoUrl).AbsolutePath.TrimStart '/'
+
+    pathPart.TrimEnd('/').Split('/').[0]
+
+let CheckIsGitHubFork (owner: string) (repo: string) : Option<bool> =
+    use httpClient = new System.Net.Http.HttpClient()
+
+    // required or HTTP call will fail
+    httpClient.DefaultRequestHeaders.UserAgent.ParseAdd "dotnet-fsi"
+
+    let apiUrl = sprintf "https://api.github.com/repos/%s/%s" owner repo
+
+    try
+        let response =
+            httpClient.GetStringAsync apiUrl
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+
+        Some(response.Contains "\"fork\":true")
+    with
+    | _ -> None
+
 let branchExists =
     let output =
         Process
@@ -65,47 +93,169 @@ let branchExists =
 
     output.Contains branchName
 
-// 2) Create subfolder with same name as repo (fail if already exists)
-if Directory.Exists repoName then
-    Console.Error.WriteLine(sprintf "Directory '%s' already exists." repoName)
-    Environment.Exit 2
+// 2) Handle directory creation or validate existing clone
+let isExistingClone =
+    if Directory.Exists repoName then
+        let gitFile = Path.Combine(repoName, ".git")
+        let bareDir = Path.Combine(repoName, ".bare")
 
-Directory.CreateDirectory repoName |> ignore<DirectoryInfo>
+        if not(File.Exists gitFile) || not(Directory.Exists bareDir) then
+            Console.Error.WriteLine(
+                sprintf
+                    "Directory '%s' already exists and is not a clone."
+                    repoName
+            )
+
+            Environment.Exit 2
+
+        true
+    else
+        false
+
+if not isExistingClone then
+    Directory.CreateDirectory repoName |> ignore<DirectoryInfo>
 
 // 3) cd into that folder
 Directory.SetCurrentDirectory repoName
 
-let cloneSpecificSingleBranch =
-    if branchExists then
-        sprintf "--branch %s" branchName
-    else
-        String.Empty
+if isExistingClone then
+    // Check if repoUrl is already a remote
+    let remoteOutput =
+        Process
+            .Execute(
+                {
+                    Command = "git"
+                    Arguments = "remote --verbose"
+                },
+                Echo.Off
+            )
+            .UnwrapDefault()
 
-// 4) git clone --single-branch --bare <repository-url> .bare
-let gitClone =
-    {
-        Command = "git"
-        Arguments =
-            sprintf
-                "clone --single-branch %s --bare -- %s .bare"
-                cloneSpecificSingleBranch
-                repoUrl
-    }
+    let remoteAlreadyExists =
+        Misc.CrossPlatformStringSplitInLines remoteOutput
+        |> Seq.exists(fun line -> line.Contains repoUrl)
 
-let cloneProc = Process.Execute(gitClone, Echo.All)
+    if not remoteAlreadyExists then
+        let existingRemotes =
+            Misc.CrossPlatformStringSplitInLines remoteOutput
+            |> Seq.choose(fun line ->
+                let trimmed = line.Trim()
 
-match cloneProc.Result with
-| Error _ ->
-    // Clean up the directory we created
-    Directory.SetCurrentDirectory("..")
-    Directory.Delete(repoName, true)
-    Console.Error.WriteLine "Git clone failed."
-    Environment.Exit 3
-| WarningsOrAmbiguous _
-| Success _ -> ()
+                if String.IsNullOrEmpty trimmed then
+                    None
+                else
+                    let parts =
+                        trimmed.Split(
+                            [| ' '; '\t' |],
+                            StringSplitOptions.RemoveEmptyEntries
+                        )
 
-// 5) Create .git file pointing to ./.bare (using F# instead of echo)
-File.WriteAllText(".git", "gitdir: ./.bare" + Environment.NewLine)
+                    if parts.Length > 0 then
+                        Some parts.[0]
+                    else
+                        None
+            )
+            |> Seq.distinct
+            |> Seq.toList
+
+        let isGitHubUrl =
+            repoUrl.Contains("github.com", StringComparison.OrdinalIgnoreCase)
+
+        let remoteName =
+            if not isGitHubUrl then
+                failwithf
+                    "Directory '%s' already exists; URL is not GitHub so API cannot be queried to find best name for new remote"
+                    repoName
+            else
+                match CheckIsGitHubFork ghOwner repoName with
+                | Some false ->
+                    if not(List.contains "upstream" existingRemotes) then
+                        "upstream"
+                    elif not(List.contains "origin" existingRemotes) then
+                        "origin"
+                    else
+                        Console.Error.WriteLine(
+                            "Both 'upstream' and 'origin' remotes already exist and the new remote is not a fork. Cannot determine a name for the new remote."
+                        )
+
+                        Environment.Exit 3
+                        String.Empty
+                | Some true -> sprintf "%sFork" ghOwner
+                | None ->
+                    Console.Error.WriteLine(
+                        "Could not check whether the repo is a GitHub fork. Cannot determine a name for the new remote."
+                    )
+
+                    Environment.Exit 3
+                    String.Empty
+
+        let addRemoteProc =
+            Process.Execute(
+                {
+                    Command = "git"
+                    Arguments = sprintf "remote add %s %s" remoteName repoUrl
+                },
+                Echo.All
+            )
+
+        match addRemoteProc.Result with
+        | Error _ ->
+            Console.Error.WriteLine(
+                sprintf "Failed to add remote '%s'." repoUrl
+            )
+
+            Environment.Exit 3
+        | WarningsOrAmbiguous _
+        | Success _ -> ()
+
+    // Fetch all remotes
+    let fetchProc =
+        Process.Execute(
+            {
+                Command = "git"
+                Arguments = "fetch --all"
+            },
+            Echo.All
+        )
+
+    match fetchProc.Result with
+    | Error _ ->
+        Console.Error.WriteLine "Git fetch --all failed."
+        Environment.Exit 3
+    | WarningsOrAmbiguous _
+    | Success _ -> ()
+else
+    let cloneSpecificSingleBranch =
+        if branchExists then
+            sprintf "--branch %s" branchName
+        else
+            String.Empty
+
+    // 4) git clone --single-branch --bare <repository-url> .bare
+    let gitClone =
+        {
+            Command = "git"
+            Arguments =
+                sprintf
+                    "clone --single-branch %s --bare -- %s .bare"
+                    cloneSpecificSingleBranch
+                    repoUrl
+        }
+
+    let cloneProc = Process.Execute(gitClone, Echo.All)
+
+    match cloneProc.Result with
+    | Error _ ->
+        // Clean up the directory we created
+        Directory.SetCurrentDirectory("..")
+        Directory.Delete(repoName, true)
+        Console.Error.WriteLine "Git clone failed."
+        Environment.Exit 3
+    | WarningsOrAmbiguous _
+    | Success _ -> ()
+
+    // 5) Create .git file pointing to ./.bare (using F# instead of echo)
+    File.WriteAllText(".git", "gitdir: ./.bare" + Environment.NewLine)
 
 // 6) Find default branch
 let gitSymbolicRef =
@@ -173,66 +323,37 @@ Console.WriteLine(
 )
 
 // 9) If repo is a GitHub fork, rename 'origin' remote to '<owner>Fork'
-let isGitHubUrl =
-    repoUrl.Contains("github.com", StringComparison.OrdinalIgnoreCase)
+if not isExistingClone then
+    let isGitHubUrl =
+        repoUrl.Contains("github.com", StringComparison.OrdinalIgnoreCase)
 
-if isGitHubUrl then
-    let ghOwner =
-        let pathPart =
-            if repoUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
-                let colonIndex = repoUrl.IndexOf ':'
-                repoUrl.Substring(colonIndex + 1)
-            else
-                (Uri repoUrl).AbsolutePath.TrimStart '/'
-
-        pathPart.TrimEnd('/').Split('/').[0]
-
-    use httpClient = new System.Net.Http.HttpClient()
-
-    // required or HTTP call will fail
-    httpClient.DefaultRequestHeaders.UserAgent.ParseAdd "dotnet-fsi"
-
-    let apiUrl = sprintf "https://api.github.com/repos/%s/%s" ghOwner repoName
-
-    let maybeResponse =
-        try
-            httpClient.GetStringAsync apiUrl
-            |> Async.AwaitTask
-            |> Async.RunSynchronously
-            |> Some
-        with
-        | _ ->
+    if isGitHubUrl then
+        match CheckIsGitHubFork ghOwner repoName with
+        | None ->
             Console.Error.WriteLine(
                 "Could not check whether the repo is a GitHub fork. Skipping remote rename."
             )
+        | Some isFork ->
+            if isFork then
+                let newRemoteName = sprintf "%sFork" ghOwner
+                let renameArgs = sprintf "remote rename origin %s" newRemoteName
 
-            None
+                let gitRemoteRename =
+                    {
+                        Command = "git"
+                        Arguments = renameArgs
+                    }
 
-    match maybeResponse with
-    | None -> ()
-    | Some response ->
-        let isFork = response.Contains "\"fork\":true"
+                let renameProc = Process.Execute(gitRemoteRename, Echo.All)
 
-        if isFork then
-            let newRemoteName = sprintf "%sFork" ghOwner
-            let renameArgs = sprintf "remote rename origin %s" newRemoteName
+                match renameProc.Result with
+                | Error _ ->
+                    Console.Error.WriteLine(
+                        sprintf
+                            "Failed to rename remote 'origin' to '%s'."
+                            newRemoteName
+                    )
 
-            let gitRemoteRename =
-                {
-                    Command = "git"
-                    Arguments = renameArgs
-                }
-
-            let renameProc = Process.Execute(gitRemoteRename, Echo.All)
-
-            match renameProc.Result with
-            | Error _ ->
-                Console.Error.WriteLine(
-                    sprintf
-                        "Failed to rename remote 'origin' to '%s'."
-                        newRemoteName
-                )
-
-                Environment.Exit 6
-            | WarningsOrAmbiguous _
-            | Success _ -> ()
+                    Environment.Exit 6
+                | WarningsOrAmbiguous _
+                | Success _ -> ()


### PR DESCRIPTION
Fixes #276

This change modifies cloneWorkTree.fsx so that when the target directory already exists, it:
- Checks if the directory has a `.git` file and a `.bare` subdirectory.
- If not, fails with a descriptive error.
- If yes, checks if the supplied repoURL is already a remote.
- If not already a remote, adds it.
- Performs `git fetch --all`.
- Creates a worktree with the name of the 2nd argument, preserving the existing branchExists logic.