### PR TITLE
fix(scripts/clonePR.fsx): use SSH remote instead of HTTPS

### DIFF
--- a/scripts/clonePR.fsx
+++ b/scripts/clonePR.fsx
@@ -87,7 +87,7 @@ let headRepoUrl =
         prJson
             .GetProperty("head")
             .GetProperty("repo")
-            .GetProperty("clone_url")
+            .GetProperty("ssh_url")
             .AsString()
     with
     | ex ->


### PR DESCRIPTION
Fixes #280

Changes `clone_url` to `ssh_url` in the GitHub API response parsing, so that the cloned PR working tree uses an SSH-based remote. This makes it easier to push further commits back to the PR branch.