### PR TITLE
fix(scripts): use targetDir approach instead of hardcoded rootDir

### DIFF
--- a/scripts/compileFSharpScripts.fsx
+++ b/scripts/compileFSharpScripts.fsx
@@ -34,8 +34,11 @@ Fsdk
 |> ignore<string>
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
 
-Helpers.GetFiles rootDir "*.fsx"
+let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
+
+Helpers.GetFiles targetDir "*.fsx"
 |> Seq.iter(fun fileInfo ->
     Fsdk
         .Process

--- a/scripts/eofConvention.fsx
+++ b/scripts/eofConvention.fsx
@@ -12,10 +12,13 @@ open System
 open type FileConventions.EolAtEof
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
+
+let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let invalidFiles =
     Helpers.GetInvalidFiles
-        rootDir
+        targetDir
         "*.*"
         (fun fileInfo -> FileConventions.EolAtEof fileInfo = False)
 

--- a/scripts/mixedLineEndings.fsx
+++ b/scripts/mixedLineEndings.fsx
@@ -10,9 +10,12 @@ open System.IO
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
+
+let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let invalidFiles =
-    Helpers.GetInvalidFiles rootDir "*.*" FileConventions.MixedLineEndings
+    Helpers.GetInvalidFiles targetDir "*.*" FileConventions.MixedLineEndings
 
 Helpers.AssertNoInvalidFiles
     invalidFiles

--- a/scripts/nonVerboseFlagsInGitHubCIAndScripts.fsx
+++ b/scripts/nonVerboseFlagsInGitHubCIAndScripts.fsx
@@ -10,6 +10,9 @@ open System.IO
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
+
+let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let validExtensions =
     seq {
@@ -23,7 +26,7 @@ let invalidFiles =
     validExtensions
     |> Seq.collect(fun ext ->
         Helpers.GetInvalidFiles
-            rootDir
+            targetDir
             ("*" + ext)
             FileConventions.NonVerboseFlags
     )

--- a/scripts/shebangConvention.fsx
+++ b/scripts/shebangConvention.fsx
@@ -10,10 +10,13 @@ open System.IO
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
+
+let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let invalidFiles =
     Helpers.GetInvalidFiles
-        rootDir
+        targetDir
         "*.fsx"
         (fun fileInfo -> not(FileConventions.HasCorrectShebang fileInfo))
 

--- a/scripts/unpinnedDotnetToolInstallVersions.fsx
+++ b/scripts/unpinnedDotnetToolInstallVersions.fsx
@@ -10,10 +10,13 @@ open System.IO
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
+
+let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let invalidFiles =
     Helpers.GetInvalidFiles
-        rootDir
+        targetDir
         "*.yml"
         FileConventions.DetectUnpinnedDotnetToolInstallVersions
 

--- a/scripts/unpinnedGitHubActionsImageVersions.fsx
+++ b/scripts/unpinnedGitHubActionsImageVersions.fsx
@@ -10,10 +10,13 @@ open System.IO
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
+
+let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let invalidFiles =
     Helpers.GetInvalidFiles
-        rootDir
+        targetDir
         "*.yml"
         FileConventions.DetectUnpinnedVersionsInGitHubCI
 

--- a/scripts/unpinnedNugetPackageReferenceVersionsInFSharpScripts.fsx
+++ b/scripts/unpinnedNugetPackageReferenceVersionsInFSharpScripts.fsx
@@ -10,10 +10,13 @@ open System.IO
 #load "../src/FileConventions/Helpers.fs"
 
 let rootDir = Path.Combine(__SOURCE_DIRECTORY__, "..") |> DirectoryInfo
+let currentDir = Directory.GetCurrentDirectory() |> DirectoryInfo
+
+let targetDir, _ = Helpers.PreferLessDeeplyNestedDir currentDir rootDir
 
 let invalidFiles =
     Helpers.GetInvalidFiles
-        rootDir
+        targetDir
         "*.fsx"
         FileConventions.DetectMissingVersionsInNugetPackageReferences
 


### PR DESCRIPTION
Fixes #285

Many .fsx scripts in the scripts/ folder hardcoded the directory to act on (e.g. \"rootDir\") instead of using a proper targetDir approach via Helpers.PreferLessDeeplyNestedDir. This change fixes the following scripts to prefer the current working directory (less deeply nested) over the source directory, making them reusable by external repos:

- compileFSharpScripts.fsx
- eofConvention.fsx
- mixedLineEndings.fsx
- nonVerboseFlagsInGitHubCIAndScripts.fsx
- shebangConvention.fsx
- unpinnedDotnetToolInstallVersions.fsx
- unpinnedGitHubActionsImageVersions.fsx
- unpinnedNugetPackageReferenceVersionsInFSharpScripts.fsx

Each script now uses the same pattern already adopted by inconsistentNugetVersionsInFSharpScripts.fsx and executableConvention.fsx:

- Get rootDir from __SOURCE_DIRECTORY__
- Get currentDir from Directory.GetCurrentDirectory()
- Use Helpers.PreferLessDeeplyNestedDir to pick targetDir
- Run checks on targetDir