### PR TITLE
feat(cloneWorkTree.fsx): allow receiving folder name as 1st argument

### DIFF
--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -15,52 +15,104 @@ let args = Misc.FsxOnlyArguments()
 
 if args.Length <> 2 then
     Console.Error.WriteLine
-        $"Usage: dotnet fsi {__SOURCE_FILE__} <repoUrl> <branchName>"
+        $"Usage: dotnet fsi {__SOURCE_FILE__} <repoUrl|folderPath> <branchName>"
 
     Environment.Exit 1
 
-let repoUrl = args.[0]
+let firstArg = args.[0]
 let branchName = args.[1]
 
 // Sanitize branch name for use as a folder name by replacing slashes/backslashes with dashes
 let branchFolderName = branchName.Replace('/', '-').Replace('\\', '-')
 
-// 1) Extract repo name from URL
-let repoName =
-    let pathPart =
-        if repoUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
-            // SCP-style SSH URL: git@host:path/to/repo.git
-            let colonIndex = repoUrl.IndexOf(':')
+let IsUrl(str: string) : bool =
+    str.Contains("://")
+    || str.StartsWith("git@", StringComparison.OrdinalIgnoreCase)
 
-            if colonIndex < 0 then
-                failwith "Invalid SCP-style git URL: missing ':' separator"
+let isUrl = IsUrl firstArg
 
-            repoUrl.Substring(colonIndex + 1)
-        else
-            // Standard URI (https, ssh://, file://, etc.)
-            let uri = Uri repoUrl
-            uri.AbsolutePath
+// 1) Extract repo name from URL, or validate folder path
+let repoUrl, repoName, isExistingClone =
+    if isUrl then
+        let url = firstArg
 
-    let segments = pathPart.TrimEnd('/').Split('/')
-    let lastSegmentOpt = Array.tryLast segments
+        let name =
+            let pathPart =
+                if url.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
+                    // SCP-style SSH URL: git@host:path/to/repo.git
+                    let colonIndex = url.IndexOf(':')
 
-    match lastSegmentOpt with
-    | None -> failwith "Unreachable"
-    | Some lastSegment ->
-        if lastSegment.EndsWith(".git", StringComparison.OrdinalIgnoreCase) then
-            lastSegment.Substring(0, lastSegment.Length - ".git".Length)
-        else
-            lastSegment
+                    if colonIndex < 0 then
+                        failwith
+                            "Invalid SCP-style git URL: missing ':' separator"
+
+                    url.Substring(colonIndex + 1)
+                else
+                    // Standard URI (https, ssh://, file://, etc.)
+                    let uri = Uri url
+                    uri.AbsolutePath
+
+            let segments = pathPart.TrimEnd('/').Split('/')
+            let lastSegmentOpt = Array.tryLast segments
+
+            match lastSegmentOpt with
+            | None -> failwith "Unreachable"
+            | Some lastSegment ->
+                if
+                    lastSegment.EndsWith
+                        (
+                            ".git",
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                then
+                    lastSegment.Substring(0, lastSegment.Length - ".git".Length)
+                else
+                    lastSegment
+
+        let existing =
+            Directory.Exists name
+            && File.Exists(Path.Combine(name, ".git"))
+            && Directory.Exists(Path.Combine(name, ".bare"))
+
+        url, name, existing
+    else
+        let fullPath = Path.GetFullPath firstArg
+
+        if not(Directory.Exists fullPath) then
+            Console.Error.WriteLine(
+                sprintf "Directory '%s' does not exist." firstArg
+            )
+
+            Environment.Exit 2
+
+        let gitFile = Path.Combine(fullPath, ".git")
+        let bareDir = Path.Combine(fullPath, ".bare")
+
+        if not(File.Exists gitFile) || not(Directory.Exists bareDir) then
+            Console.Error.WriteLine(
+                sprintf
+                    "Directory '%s' already exists and is not a clone."
+                    firstArg
+            )
+
+            Environment.Exit 2
+
+        let name = Path.GetFileName(Path.TrimEndingDirectorySeparator fullPath)
+
+        String.Empty, name, true
 
 let ghOwner =
-    let pathPart =
-        if repoUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
-            let colonIndex = repoUrl.IndexOf ':'
-            repoUrl.Substring(colonIndex + 1)
-        else
-            (Uri repoUrl).AbsolutePath.TrimStart '/'
+    if isUrl then
+        let pathPart =
+            if repoUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
+                let colonIndex = repoUrl.IndexOf ':'
+                repoUrl.Substring(colonIndex + 1)
+            else
+                (Uri repoUrl).AbsolutePath.TrimStart '/'
 
-    pathPart.TrimEnd('/').Split('/').[0]
+        pathPart.TrimEnd('/').Split('/').[0]
+    else
+        String.Empty
 
 let CheckIsGitHubFork (owner: string) (repo: string) : Option<bool> =
     use httpClient = new System.Net.Http.HttpClient()
@@ -80,136 +132,155 @@ let CheckIsGitHubFork (owner: string) (repo: string) : Option<bool> =
     with
     | _ -> None
 
-let branchExists =
-    let output =
-        Process
-            .Execute(
-                {
-                    Command = "git"
-                    Arguments =
-                        sprintf "ls-remote --heads %s %s" repoUrl branchName
-                },
-                Echo.Off
-            )
-            .UnwrapDefault()
-            .Trim()
+// Check branch existence on remote only when a URL was given
+let remoteBranchExists =
+    if not isUrl then
+        false
+    else
+        let output =
+            Process
+                .Execute(
+                    {
+                        Command = "git"
+                        Arguments =
+                            sprintf "ls-remote --heads %s %s" repoUrl branchName
+                    },
+                    Echo.Off
+                )
+                .UnwrapDefault()
+                .Trim()
 
-    output.Contains branchName
+        output.Contains branchName
 
 // 2) Handle directory creation or validate existing clone
-let isExistingClone =
-    if Directory.Exists repoName then
-        let gitFile = Path.Combine(repoName, ".git")
-        let bareDir = Path.Combine(repoName, ".bare")
-
-        if not(File.Exists gitFile) || not(Directory.Exists bareDir) then
-            Console.Error.WriteLine(
-                sprintf
-                    "Directory '%s' already exists and is not a clone."
-                    repoName
-            )
-
-            Environment.Exit 2
-
-        true
-    else
-        false
-
 if not isExistingClone then
     Directory.CreateDirectory repoName |> ignore<DirectoryInfo>
 
 // 3) cd into that folder
-Directory.SetCurrentDirectory repoName
+let targetDir =
+    if isUrl then
+        repoName
+    else
+        firstArg
 
-if isExistingClone then
-    // Check if repoUrl is already a remote
-    let remoteOutput =
-        Process
-            .Execute(
+Directory.SetCurrentDirectory targetDir
+
+// Determine branch existence after entering the directory
+let branchExists =
+    if isUrl then
+        remoteBranchExists
+    else
+        let localCheck =
+            Process.Execute(
                 {
                     Command = "git"
-                    Arguments = "remote --verbose"
+                    Arguments =
+                        sprintf
+                            "rev-parse --verify --quiet refs/heads/%s"
+                            branchName
                 },
                 Echo.Off
             )
-            .UnwrapDefault()
 
-    let remoteAlreadyExists =
-        Misc.CrossPlatformStringSplitInLines remoteOutput
-        |> Seq.exists(fun line -> line.Contains repoUrl)
+        match localCheck.Result with
+        | Error _ -> false
+        | WarningsOrAmbiguous _
+        | Success _ -> true
 
-    if not remoteAlreadyExists then
-        let existingRemotes =
+if isExistingClone then
+    if isUrl then
+        // Check if repoUrl is already a remote
+        let remoteOutput =
+            Process
+                .Execute(
+                    {
+                        Command = "git"
+                        Arguments = "remote --verbose"
+                    },
+                    Echo.Off
+                )
+                .UnwrapDefault()
+
+        let remoteAlreadyExists =
             Misc.CrossPlatformStringSplitInLines remoteOutput
-            |> Seq.choose(fun line ->
-                let trimmed = line.Trim()
+            |> Seq.exists(fun line -> line.Contains repoUrl)
 
-                if String.IsNullOrEmpty trimmed then
-                    None
-                else
-                    let parts =
-                        trimmed.Split(
-                            [| ' '; '\t' |],
-                            StringSplitOptions.RemoveEmptyEntries
-                        )
+        if not remoteAlreadyExists then
+            let existingRemotes =
+                Misc.CrossPlatformStringSplitInLines remoteOutput
+                |> Seq.choose(fun line ->
+                    let trimmed = line.Trim()
 
-                    if parts.Length > 0 then
-                        Some parts.[0]
-                    else
+                    if String.IsNullOrEmpty trimmed then
                         None
-            )
-            |> Seq.distinct
-            |> Seq.toList
-
-        let isGitHubUrl =
-            repoUrl.Contains("github.com", StringComparison.OrdinalIgnoreCase)
-
-        let remoteName =
-            if not isGitHubUrl then
-                failwithf
-                    "Directory '%s' already exists; URL is not GitHub so API cannot be queried to find best name for new remote"
-                    repoName
-            else
-                match CheckIsGitHubFork ghOwner repoName with
-                | Some false ->
-                    if not(List.contains "upstream" existingRemotes) then
-                        "upstream"
-                    elif not(List.contains "origin" existingRemotes) then
-                        "origin"
                     else
+                        let parts =
+                            trimmed.Split(
+                                [| ' '; '\t' |],
+                                StringSplitOptions.RemoveEmptyEntries
+                            )
+
+                        if parts.Length > 0 then
+                            Some parts.[0]
+                        else
+                            None
+                )
+                |> Seq.distinct
+                |> Seq.toList
+
+            let isGitHubUrl =
+                repoUrl.Contains(
+                    "github.com",
+                    StringComparison.OrdinalIgnoreCase
+                )
+
+            let remoteName =
+                if not isGitHubUrl then
+                    failwithf
+                        "Directory '%s' already exists; URL is not GitHub so API cannot be queried to find best name for new remote"
+                        repoName
+                else
+                    match CheckIsGitHubFork ghOwner repoName with
+                    | Some false ->
+                        if not(List.contains "upstream" existingRemotes) then
+                            "upstream"
+                        elif not(List.contains "origin" existingRemotes) then
+                            "origin"
+                        else
+                            Console.Error.WriteLine(
+                                "Both 'upstream' and 'origin' remotes already exist and the new remote is not a fork. Cannot determine a name for the new remote."
+                            )
+
+                            Environment.Exit 3
+                            String.Empty
+                    | Some true -> sprintf "%sFork" ghOwner
+                    | None ->
                         Console.Error.WriteLine(
-                            "Both 'upstream' and 'origin' remotes already exist and the new remote is not a fork. Cannot determine a name for the new remote."
+                            "Could not check whether the repo is a GitHub fork. Cannot determine a name for the new remote."
                         )
 
                         Environment.Exit 3
                         String.Empty
-                | Some true -> sprintf "%sFork" ghOwner
-                | None ->
-                    Console.Error.WriteLine(
-                        "Could not check whether the repo is a GitHub fork. Cannot determine a name for the new remote."
-                    )
 
-                    Environment.Exit 3
-                    String.Empty
+            let addRemoteProc =
+                Process.Execute(
+                    {
+                        Command = "git"
+                        Arguments =
+                            sprintf "remote add %s %s" remoteName repoUrl
+                    },
+                    Echo.All
+                )
 
-        let addRemoteProc =
-            Process.Execute(
-                {
-                    Command = "git"
-                    Arguments = sprintf "remote add %s %s" remoteName repoUrl
-                },
-                Echo.All
-            )
+            match addRemoteProc.Result with
+            | Error _ ->
+                Console.Error.WriteLine(
+                    sprintf "Failed to add remote '%s'." repoUrl
+                )
 
-        match addRemoteProc.Result with
-        | Error _ ->
-            Console.Error.WriteLine(
-                sprintf "Failed to add remote '%s'." repoUrl
-            )
-
-            Environment.Exit 3
-        | WarningsOrAmbiguous _
-        | Success _ -> ()
+                Environment.Exit 3
+            | WarningsOrAmbiguous _
+            | Success _ -> ()
 
     // Fetch all remotes
     let fetchProc =

--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -11,13 +11,50 @@ open System.Configuration
 open Fsdk
 open Fsdk.Process
 
+let errUsage =
+    (1, $"Usage: dotnet fsi {__SOURCE_FILE__} <repoUrl|folderPath> <branchName>")
+
+let ErrDirectoryDoesNotExist path =
+    (2, sprintf "Directory '%s' does not exist." path)
+
+let ErrDirectoryIsNotClone path =
+    (3, sprintf "Directory '%s' already exists and is not a clone." path)
+
+let errCannotDetermineRemoteName =
+    (4,
+     "Both 'upstream' and 'origin' remotes already exist and the new remote is not a fork. Cannot determine a name for the new remote.")
+
+let errCannotCheckGitHubFork =
+    (5,
+     "Could not check whether the repo is a GitHub fork. Cannot determine a name for the new remote.")
+
+let ErrFailedToAddRemote url =
+    (6, sprintf "Failed to add remote '%s'." url)
+
+let errGitFetchAllFailed = (7, "Git fetch --all failed.")
+
+let errGitCloneFailed = (8, "Git clone failed.")
+
+let ErrNotGitHubCannotDetermineRemoteName dir =
+    (9,
+     sprintf
+         "Directory '%s' already exists; URL is not GitHub so API cannot be queried to find best name for new remote"
+         dir)
+
+let errGitWorktreeAddFailed = (10, "Git worktree add failed.")
+
+let errGitCheckoutFailed = (11, "Git checkout -b failed.")
+
+let ErrFailedToRenameRemote newName =
+    (12, sprintf "Failed to rename remote 'origin' to '%s'." newName)
+
 let args = Misc.FsxOnlyArguments()
 
 if args.Length <> 2 then
-    Console.Error.WriteLine
-        $"Usage: dotnet fsi {__SOURCE_FILE__} <repoUrl|folderPath> <branchName>"
+    let exitCode, errMsg = errUsage
+    Console.Error.WriteLine errMsg
 
-    Environment.Exit 1
+    Environment.Exit exitCode
 
 let firstArg = args.[0]
 let branchName = args.[1]
@@ -79,23 +116,19 @@ let repoUrl, repoName, isExistingClone =
         let fullPath = Path.GetFullPath firstArg
 
         if not(Directory.Exists fullPath) then
-            Console.Error.WriteLine(
-                sprintf "Directory '%s' does not exist." firstArg
-            )
+            let exitCode, errMsg = ErrDirectoryDoesNotExist firstArg
+            Console.Error.WriteLine errMsg
 
-            Environment.Exit 2
+            Environment.Exit exitCode
 
         let gitFile = Path.Combine(fullPath, ".git")
         let bareDir = Path.Combine(fullPath, ".bare")
 
         if not(File.Exists gitFile) || not(Directory.Exists bareDir) then
-            Console.Error.WriteLine(
-                sprintf
-                    "Directory '%s' already exists and is not a clone."
-                    firstArg
-            )
+            let exitCode, errMsg = ErrDirectoryIsNotClone firstArg
+            Console.Error.WriteLine errMsg
 
-            Environment.Exit 2
+            Environment.Exit exitCode
 
         let name = Path.GetFileName(Path.TrimEndingDirectorySeparator fullPath)
 
@@ -236,9 +269,12 @@ if isExistingClone then
 
             let remoteName =
                 if not isGitHubUrl then
-                    failwithf
-                        "Directory '%s' already exists; URL is not GitHub so API cannot be queried to find best name for new remote"
-                        repoName
+                    let exitCode, errMsg =
+                        ErrNotGitHubCannotDetermineRemoteName repoName
+
+                    Console.Error.WriteLine errMsg
+                    Environment.Exit exitCode
+                    failwith <| "Unreachable because of: " + errMsg
                 else
                     match CheckIsGitHubFork ghOwner repoName with
                     | Some false ->
@@ -247,20 +283,18 @@ if isExistingClone then
                         elif not(List.contains "origin" existingRemotes) then
                             "origin"
                         else
-                            Console.Error.WriteLine(
-                                "Both 'upstream' and 'origin' remotes already exist and the new remote is not a fork. Cannot determine a name for the new remote."
-                            )
+                            let exitCode, errMsg = errCannotDetermineRemoteName
+                            Console.Error.WriteLine errMsg
 
-                            Environment.Exit 3
-                            String.Empty
+                            Environment.Exit exitCode
+                            failwith <| "Unreachable because of: " + errMsg
                     | Some true -> sprintf "%sFork" ghOwner
                     | None ->
-                        Console.Error.WriteLine(
-                            "Could not check whether the repo is a GitHub fork. Cannot determine a name for the new remote."
-                        )
+                        let exitCode, errMsg = errCannotCheckGitHubFork
+                        Console.Error.WriteLine errMsg
 
-                        Environment.Exit 3
-                        String.Empty
+                        Environment.Exit exitCode
+                        failwith <| "Unreachable because of: " + errMsg
 
             let addRemoteProc =
                 Process.Execute(
@@ -274,11 +308,10 @@ if isExistingClone then
 
             match addRemoteProc.Result with
             | Error _ ->
-                Console.Error.WriteLine(
-                    sprintf "Failed to add remote '%s'." repoUrl
-                )
+                let exitCode, errMsg = ErrFailedToAddRemote repoUrl
+                Console.Error.WriteLine errMsg
 
-                Environment.Exit 3
+                Environment.Exit exitCode
             | WarningsOrAmbiguous _
             | Success _ -> ()
 
@@ -294,8 +327,9 @@ if isExistingClone then
 
     match fetchProc.Result with
     | Error _ ->
-        Console.Error.WriteLine "Git fetch --all failed."
-        Environment.Exit 3
+        let exitCode, errMsg = errGitFetchAllFailed
+        Console.Error.WriteLine errMsg
+        Environment.Exit exitCode
     | WarningsOrAmbiguous _
     | Success _ -> ()
 else
@@ -323,8 +357,9 @@ else
         // Clean up the directory we created
         Directory.SetCurrentDirectory("..")
         Directory.Delete(repoName, true)
-        Console.Error.WriteLine "Git clone failed."
-        Environment.Exit 3
+        let exitCode, errMsg = errGitCloneFailed
+        Console.Error.WriteLine errMsg
+        Environment.Exit exitCode
     | WarningsOrAmbiguous _
     | Success _ -> ()
 
@@ -358,8 +393,9 @@ let worktreeProc = Process.Execute(gitWorktreeAdd, Echo.All)
 
 match worktreeProc.Result with
 | Error _ ->
-    Console.Error.WriteLine "Git worktree add failed."
-    Environment.Exit 4
+    let exitCode, errMsg = errGitWorktreeAddFailed
+    Console.Error.WriteLine errMsg
+    Environment.Exit exitCode
 | WarningsOrAmbiguous _
 | Success _ -> ()
 
@@ -379,12 +415,9 @@ if not branchExists then
 
     match checkoutProc.Result with
     | Error _ ->
-        if branchExists then
-            Console.Error.WriteLine("Git switch failed.")
-        else
-            Console.Error.WriteLine("Git checkout -b failed.")
-
-        Environment.Exit 5
+        let exitCode, errMsg = errGitCheckoutFailed
+        Console.Error.WriteLine errMsg
+        Environment.Exit exitCode
     | WarningsOrAmbiguous _
     | Success _ -> ()
 
@@ -422,12 +455,9 @@ if not isExistingClone then
 
                 match renameProc.Result with
                 | Error _ ->
-                    Console.Error.WriteLine(
-                        sprintf
-                            "Failed to rename remote 'origin' to '%s'."
-                            newRemoteName
-                    )
+                    let exitCode, errMsg = ErrFailedToRenameRemote newRemoteName
 
-                    Environment.Exit 6
+                    Console.Error.WriteLine errMsg
+                    Environment.Exit exitCode
                 | WarningsOrAmbiguous _
                 | Success _ -> ()


### PR DESCRIPTION
Fixes #286

Right now cloneWorkTree.fsx only accepts a URL as its first argument.

However, we could make it support a folder name instead of a URL. So:
* If 1st argument doesn't look like a URL but a relative path, check if the path points to a directory that exists.
* If it exists and is a git clone (so, check for `.git` file and `.bare` directory like we already do in another part of the code), then act like the folder is already cloned, so similar scenario as we did in ce46d24e88141a4255cdc17f09a8be51de2032c9 : continue as normal, doing `fetch --all`, etc.

Changes include:
- Updated usage message to indicate `<repoUrl|folderPath>` is supported.
- Added `IsUrl` helper to distinguish URLs from folder paths.
- When the first argument is a folder path, verify it exists and contains `.git` and `.bare`.
- In existing-clone mode, skip adding a remote if no URL was given (folder mode).
- Branch existence is checked locally via `git rev-parse` when in folder mode instead of `git ls-remote`.