### PR TITLE
fix(cloneWorkTree.fsx): use 'git worktree add -b' for new branches

### DIFF
--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -382,12 +382,19 @@ let baseBranch =
             .UnwrapDefault()
             .Trim()
 
-// 7) git worktree add <defaultBranch> <branchName>
+// 7) git worktree add
 let gitWorktreeAdd =
-    {
-        Command = "git"
-        Arguments = sprintf "worktree add %s %s" branchFolderName baseBranch
-    }
+    if branchExists then
+        {
+            Command = "git"
+            Arguments = sprintf "worktree add %s %s" branchFolderName baseBranch
+        }
+    else
+        {
+            Command = "git"
+            Arguments =
+                sprintf "worktree add -b %s %s" branchName branchFolderName
+        }
 
 let worktreeProc = Process.Execute(gitWorktreeAdd, Echo.All)
 
@@ -399,27 +406,8 @@ match worktreeProc.Result with
 | WarningsOrAmbiguous _
 | Success _ -> ()
 
-// 8) cd into branchName and create branch
+// 8) cd into branchName
 Directory.SetCurrentDirectory branchFolderName
-
-if not branchExists then
-    let checkoutArgs = sprintf "checkout -b %s" branchName
-
-    let gitCheckout =
-        {
-            Command = "git"
-            Arguments = checkoutArgs
-        }
-
-    let checkoutProc = Process.Execute(gitCheckout, Echo.All)
-
-    match checkoutProc.Result with
-    | Error _ ->
-        let exitCode, errMsg = errGitCheckoutFailed
-        Console.Error.WriteLine errMsg
-        Environment.Exit exitCode
-    | WarningsOrAmbiguous _
-    | Success _ -> ()
 
 Console.WriteLine(
     sprintf

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -545,6 +545,7 @@ let allowedNonVerboseFlags =
 
         // git
         "checkout -b"
+        "worktree add -b"
 
         // even if env in linux has --split-string=foo as equivalent to env -S, it
         // doesn't seem to be present in macOS' env man page and doesn't work either


### PR DESCRIPTION
When creating a new branch worktree in an existing clone where the base branch is already tracked by another worktree, this command fails:

```
git worktree add newBranchName master
```

because git refuses to check out a branch that is already checked out in another worktree.

Using `git worktree add -b` creates the new branch directly from HEAD (the bare repo's default branch) without checking out an existing branch, so it bypasses the conflict.

Fixes #289