### PR TITLE
refactor(scripts): exit codes

### DIFF
--- a/scripts/checkCommits1by1.fsx
+++ b/scripts/checkCommits1by1.fsx
@@ -17,6 +17,35 @@ open Fsdk
 open Fsdk.Process
 open Fsdk.FSharpUtil
 
+let errNotGitHubCI =
+    (1, "This script is meant to be used only within a GitHubCI pipeline")
+
+let errNoAccessToken =
+    (2,
+     """Please define GITHUB_TOKEN environment variable in your GitHubCI workflow:
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+""")
+
+let errNoGitHubActions =
+    (3,
+     """
+Please activate GitHub Actions in your repository. Click on the
+"Actions" tab at the top of the repository page and click on the
+"I understand my workflows, go ahead and enable them" button.
+""")
+
+let errNotPushedOneByOne =
+    (4,
+     "Please push the commits one by one to make sure every commit has a CI status; using this script is recommended:"
+     + Environment.NewLine
+     + "https://github.com/nblockchain/conventions/blob/master/scripts/gitPush1by1.fsx")
+
+let errCiNotSuccessful =
+    (5,
+     "CI is not successful (green) for one or more commits, or it passes when a failing test is expected.")
+
 type GithubEventType =
     JsonProvider<"""
 {
@@ -1152,19 +1181,9 @@ type CheckSuitesType =
 let githubEventPath = Environment.GetEnvironmentVariable "GITHUB_EVENT_PATH"
 
 if String.IsNullOrEmpty githubEventPath then
-    Console.Error.WriteLine
-        "This script is meant to be used only within a GitHubCI pipeline"
-
-    Environment.Exit 2
-
-let githubTokenErrorMsg =
-    """Please define GITHUB_TOKEN environment variable in your GitHubCI workflow:
-
-```
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-"""
+    let exitCode, errMsg = errNotGitHubCI
+    Console.Error.WriteLine errMsg
+    Environment.Exit exitCode
 
 let accessTokenName, accessToken =
     let personalAccessToken = Environment.GetEnvironmentVariable "ACCESS_TOKEN"
@@ -1177,8 +1196,10 @@ let accessTokenName, accessToken =
         if not(String.IsNullOrEmpty githubToken) then
             "GITHUB_TOKEN", (Environment.GetEnvironmentVariable "GITHUB_TOKEN")
         else
-            Console.Error.WriteLine githubTokenErrorMsg
-            exit 1
+            let exitCode, errMsg = errNoAccessToken
+            Console.Error.WriteLine errMsg
+            Environment.Exit exitCode
+            failwith <| "Unreachable because of: " + errMsg
 
 printfn "Using access token %s" accessTokenName
 Console.WriteLine()
@@ -1319,16 +1340,10 @@ let ciStatuses =
 let gitHubActionsEnabled = ciStatuses.Any(fun (hasCiStatus, _) -> hasCiStatus)
 
 if not gitHubActionsEnabled then
-    let errMsg =
-        sprintf
-            """
-Please activate GitHub Actions in your repository. Click on the
-"Actions" tab at the top of the repository page and click on the
-"I understand my workflows, go ahead and enable them" button.
-"""
-
+    let exitCode, errMsg = errNoGitHubActions
     Console.Error.WriteLine errMsg
-    Environment.Exit 1
+    Environment.Exit exitCode
+    failwith <| "Unreachable because of: " + errMsg
 
 let notUsedGitPush1by1 =
     gitHubActionsEnabled
@@ -1337,15 +1352,11 @@ let notUsedGitPush1by1 =
     )
 
 if notUsedGitPush1by1 then
-    let errMsg =
-        sprintf
-            "Please push the commits one by one to make sure every commit has a CI status; using this script is recommended:%s%s"
-            Environment.NewLine
-            "https://github.com/nblockchain/conventions/blob/master/scripts/gitPush1by1.fsx"
-
+    let exitCode, errMsg = errNotPushedOneByOne
     Console.WriteLine()
     Console.Error.WriteLine errMsg
-    Environment.Exit 2
+    Environment.Exit exitCode
+    failwith <| "Unreachable because of: " + errMsg
 
 let expectedFailureSubstrings = [ "failing test"; "failing CI" ]
 
@@ -1411,5 +1422,8 @@ See commit '{commitHash}' for the first occurrence of this issue."""
             Console.Error.WriteLine
                 $"Hint: if you want to state that a commit can have red CI because of adding a failing test, please make sure that the commit message contains the {expectedFailureSubstringsJoined} term"
 
-            Environment.Exit 3
+            let exitCode, errMsg = errCiNotSuccessful
+            Console.Error.WriteLine errMsg
+            Environment.Exit exitCode
+            failwith <| "Unreachable because of: " + errMsg
 )

--- a/scripts/deleteAssetsFromOldReleases.fsx
+++ b/scripts/deleteAssetsFromOldReleases.fsx
@@ -14,24 +14,29 @@ open Fsdk
 open Fsdk.Process
 open Fsdk.FSharpUtil
 
+let errNotGitHubCI =
+    (1, "This script is meant to be used only within a GitHubCI pipeline.")
+
+let errNoGitHubToken =
+    (2,
+     """Please set the GITHUB_TOKEN environment variable in your GitHubCI pipeline:
+    env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+""")
+
 let githubRepository = Environment.GetEnvironmentVariable "GITHUB_REPOSITORY"
 
 if String.IsNullOrEmpty githubRepository then
-    Console.Error.WriteLine
-        "This script is meant to be used only within a GitHubCI pipeline."
-
-    Environment.Exit 2
+    let exitCode, errMsg = errNotGitHubCI
+    Console.Error.WriteLine errMsg
+    Environment.Exit exitCode
 
 let githubToken = Environment.GetEnvironmentVariable "GITHUB_TOKEN"
 
 if String.IsNullOrEmpty githubToken then
-    Console.Error.WriteLine
-        "Please set the GITHUB_TOKEN environment variable in your GitHubCI pipeline:
-    env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    "
-
-    Environment.Exit 2
+    let exitCode, errMsg = errNoGitHubToken
+    Console.Error.WriteLine errMsg
+    Environment.Exit exitCode
 
 let numberOfLatestReleasesToKeep = 2
 

--- a/scripts/deleteOldArtifacts.fsx
+++ b/scripts/deleteOldArtifacts.fsx
@@ -14,25 +14,30 @@ open Fsdk
 open Fsdk.Process
 open Fsdk.FSharpUtil
 
+let errNotGitHubCI =
+    (1, "This script is meant to be used only within a GitHubCI pipeline.")
+
+let errNoGitHubToken =
+    (2,
+     """Please set the GITHUB_TOKEN environment variable in your GitHubCI pipeline:
+
+    env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+""")
+
 let githubRepository = Environment.GetEnvironmentVariable "GITHUB_REPOSITORY"
 
 if String.IsNullOrEmpty githubRepository then
-    Console.Error.WriteLine
-        "This script is meant to be used only within a GitHubCI pipeline."
-
-    Environment.Exit 1
+    let exitCode, errMsg = errNotGitHubCI
+    Console.Error.WriteLine errMsg
+    Environment.Exit exitCode
 
 let githubToken = Environment.GetEnvironmentVariable "GITHUB_TOKEN"
 
 if String.IsNullOrEmpty githubToken then
-    Console.Error.WriteLine
-        "Please set the GITHUB_TOKEN environment variable in your GitHubCI pipeline:
-
-    env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    "
-
-    Environment.Exit 2
+    let exitCode, errMsg = errNoGitHubToken
+    Console.Error.WriteLine errMsg
+    Environment.Exit exitCode
 
 let GetPreviousCommitsHashes() =
     Fsdk

--- a/scripts/inconsistentNugetVersionsInDotNetProjects.fsx
+++ b/scripts/inconsistentNugetVersionsInDotNetProjects.fsx
@@ -17,15 +17,28 @@ open Fsdk
 
 open NugetVersionsCheck
 
+let errUsage =
+    (1, sprintf "Usage: dotnet fsi %s [example.sln(optional)]" __SOURCE_FILE__)
+
+let ErrDirectoryNotAllowed arg =
+    (2, sprintf "Use an .sln file instead of directory: '%s'" arg)
+
+let ErrFileNotFound arg =
+    (3, sprintf "'%s' does not exist." arg)
+
+let ErrInvalidArgument arg =
+    (4,
+     sprintf
+         "'%s' argument is invalid. You should enter an .sln file or run this script on current directory"
+         arg)
+
 let args = Misc.FsxOnlyArguments()
 let currentDirectory = Directory.GetCurrentDirectory()
 
 if args.Length > 1 then
-    Console.Error.WriteLine(
-        sprintf "Usage: dotnet fsi %s [example.sln(optional)]" __SOURCE_FILE__
-    )
-
-    Environment.Exit 1
+    let exitCode, errMsg = errUsage
+    Console.Error.WriteLine errMsg
+    Environment.Exit exitCode
 
 let target =
     if args.IsEmpty then
@@ -34,15 +47,22 @@ let target =
         let singleArg = args.[0]
 
         if Directory.Exists singleArg then
-            failwithf "Use an .sln file insted of directory."
+            let exitCode, errMsg = ErrDirectoryNotAllowed singleArg
+            Console.Error.WriteLine errMsg
+            Environment.Exit exitCode
+            failwith <| "Unreachable because of: " + errMsg
         elif not(File.Exists singleArg) then
-            failwithf "'%s' does not exist." singleArg
+            let exitCode, errMsg = ErrFileNotFound singleArg
+            Console.Error.WriteLine errMsg
+            Environment.Exit exitCode
+            failwith <| "Unreachable because of: " + errMsg
         elif singleArg.EndsWith ".sln" then
             singleArg |> FileInfo |> ScriptTarget.Solution
         else
-            failwithf
-                "'%s' argument is invalid. You should enter an .sln file or run this script on current directory"
-                singleArg
+            let exitCode, errMsg = ErrInvalidArgument singleArg
+            Console.Error.WriteLine errMsg
+            Environment.Exit exitCode
+            failwith <| "Unreachable because of: " + errMsg
 
 
 let nugetSolutionPackagesDir =

--- a/scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
+++ b/scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
@@ -16,6 +16,10 @@ open System.IO
 #load "../src/FileConventions/NugetVersionsCheck.fs"
 #load "../src/FileConventions/CombinedVersionCheck.fs"
 
+let errInconsistentVersions =
+    (1,
+     "Inconsistent NuGet package versions detected between F# scripts and .NET projects")
+
 let currentDir = Directory.GetCurrentDirectory()
 
 let targetDirs =
@@ -56,4 +60,6 @@ if not packagesWithMultipleVersions.IsEmpty then
         Console.Error.WriteLine
             $"Found {versions.Count} different versions of package \"{packageName}\": {versionsString}"
 
-    Environment.Exit 1
+    let exitCode, errMsg = errInconsistentVersions
+    Console.Error.WriteLine errMsg
+    Environment.Exit exitCode

--- a/scripts/replace.fsx
+++ b/scripts/replace.fsx
@@ -9,24 +9,31 @@ open System.Configuration
 #r "nuget: Fsdk, Version=0.9.99--date20260525-0605.git-a5cfc39"
 open Fsdk
 
-let args = Misc.FsxOnlyArguments()
-
 let errTooManyArgs =
-    "Can only pass two arguments, with optional flag: replace.fsx --file=a.b oldstring newstring"
+    (1,
+     "Can only pass two arguments, with optional flag: replace.fsx --file=a.b oldstring newstring")
+
+let errTooFewArgs =
+    (2, "Need to pass two arguments: replace.fsx oldstring newstring")
+
+let ErrFileNotFound path =
+    (3, sprintf "File '%s' doesn't exist" path)
 
 let note =
     "NOTE: by default, some kind of files/folders will be excluded, e.g.: .git, *.dll, *.png, ..."
 
-if args.Length > 3 then
-    Console.Error.WriteLine errTooManyArgs
-    Console.WriteLine note
-    Environment.Exit 1
-elif args.Length < 2 then
-    Console.Error.WriteLine
-        "Need to pass two arguments: replace.fsx oldstring newstring"
+let args = Misc.FsxOnlyArguments()
 
+if args.Length > 3 then
+    let exitCode, errMsg = errTooManyArgs
+    Console.Error.WriteLine errMsg
     Console.WriteLine note
-    Environment.Exit 1
+    Environment.Exit exitCode
+elif args.Length < 2 then
+    let exitCode, errMsg = errTooFewArgs
+    Console.Error.WriteLine errMsg
+    Console.WriteLine note
+    Environment.Exit exitCode
 
 let firstArg = args.[0]
 
@@ -35,15 +42,19 @@ let particularFile =
         let file = firstArg.Substring(firstArg.IndexOf("=") + 1) |> FileInfo
 
         if not file.Exists then
-            failwithf "File '%s' doesn't exist" file.FullName
+            let exitCode, errMsg = ErrFileNotFound file.FullName
+            Console.Error.WriteLine errMsg
+            Environment.Exit exitCode
+            failwith <| "Unreachable because of: " + errMsg
 
         Some file
     else
         if args.Length = 3 then
-            Console.Error.WriteLine errTooManyArgs
+            let exitCode, errMsg = errTooManyArgs
+            Console.Error.WriteLine errMsg
             Console.WriteLine note
-            Environment.Exit 1
-            failwith "Unreachable"
+            Environment.Exit exitCode
+            failwith <| "Unreachable because of: " + errMsg
 
         None
 


### PR DESCRIPTION
Refactor all .fsx scripts in scripts/ to use proper exit code helpers with descriptive tuple pairs, matching the pattern established in 750cb717d6e2df35efe371404666016bc0f684b7 and 752cb9b1872b94ab28766518341ec6568c384970.

Changes include:
- checkCommits1by1.fsx
- deleteAssetsFromOldReleases.fsx
- deleteOldArtifacts.fsx
- inconsistentNugetVersionsInDotNetProjects.fsx
- inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
- replace.fsx

Fixes #293