### PR TITLE
fix(scripts/cloneWorkTree.fsx): add branch to fetch refspec before git fetch

### DIFF
--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -315,6 +315,58 @@ if isExistingClone then
             | WarningsOrAmbiguous _
             | Success _ -> ()
 
+    // Ensure the branch is included in fetch refspec if it exists on remote
+    if isUrl && branchExists then
+        let remoteOutputForSetBranches =
+            Process
+                .Execute(
+                    {
+                        Command = "git"
+                        Arguments = "remote --verbose"
+                    },
+                    Echo.Off
+                )
+                .UnwrapDefault()
+
+        let remoteNameForUrlOpt =
+            Misc.CrossPlatformStringSplitInLines remoteOutputForSetBranches
+            |> Seq.tryPick(fun line ->
+                let trimmed = line.Trim()
+
+                if
+                    not(String.IsNullOrEmpty trimmed)
+                    && trimmed.Contains repoUrl
+                then
+                    let parts =
+                        trimmed.Split(
+                            [| ' '; '\t' |],
+                            StringSplitOptions.RemoveEmptyEntries
+                        )
+
+                    if parts.Length > 0 then
+                        Some parts.[0]
+                    else
+                        None
+                else
+                    None
+            )
+
+        match remoteNameForUrlOpt with
+        | Some remoteName ->
+            Process.Execute(
+                {
+                    Command = "git"
+                    Arguments =
+                        sprintf
+                            "remote set-branches --add %s %s"
+                            remoteName
+                            branchName
+                },
+                Echo.All
+            )
+            |> ignore
+        | None -> ()
+
     // Fetch all remotes
     let fetchProc =
         Process.Execute(


### PR DESCRIPTION
Fixes #292

## Problem

When `cloneWorkTree.fsx` is run on an existing clone to add a worktree for a branch that exists remotely but hasn't been fetched yet, `git fetch --all` would not pull the branch because the bare clone's fetch refspec only includes the default branch. As a result, `git worktree add` would create a worktree pointing to a local ref that was absent or outdated, effectively checking out the default branch (`main`) instead of the requested remote branch.

## Fix

Before `git fetch --all`, locate the remote name that corresponds to the requested `repoUrl`, then run `git remote set-branches --add <remote> <branchName>` to ensure the branch is included in the fetch refspec. This ensures the remote branch is actually fetched, so `git worktree add <folder> <branch>` correctly checks out the intended branch.

## Changes

- `scripts/cloneWorkTree.fsx`: Added logic to find the remote name for the given `repoUrl` and call `git remote set-branches --add <remote> <branchName>` when `isExistingClone`, `isUrl`, and `branchExists` are all true.