### PR TITLE
fix(scripts/cloneWorkTree.fsx): add branch to fetch refspec before git fetch --all

### DIFF
--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -2,6 +2,7 @@
 
 open System
 open System.IO
+open System.Linq
 
 #r "System.Configuration"
 open System.Configuration
@@ -10,6 +11,8 @@ open System.Configuration
 
 open Fsdk
 open Fsdk.Process
+
+let initialDir = Directory.GetCurrentDirectory()
 
 let errUsage =
     (1, $"Usage: dotnet fsi {__SOURCE_FILE__} <repoUrl|folderPath> <branchName>")
@@ -48,104 +51,70 @@ let errGitCheckoutFailed = (11, "Git checkout -b failed.")
 let ErrFailedToRenameRemote newName =
     (12, sprintf "Failed to rename remote 'origin' to '%s'." newName)
 
-let args = Misc.FsxOnlyArguments()
+type ArgType =
+    | Url of fullUrl: string * owner: string * headBranch: string
+    | FolderName
 
-if args.Length <> 2 then
-    let exitCode, errMsg = errUsage
-    Console.Error.WriteLine errMsg
+type InitialState =
+    {
+        RepoAndFolderName: string
+        ArgType: ArgType
+        AlreadyCloned: bool
+    }
 
-    Environment.Exit exitCode
-
-let firstArg = args.[0]
-let branchName = args.[1]
-
-// Sanitize branch name for use as a folder name by replacing slashes/backslashes with dashes
-let branchFolderName = branchName.Replace('/', '-').Replace('\\', '-')
+type BranchTargetInfo =
+    {
+        Name: string
+        ExistsAlready: bool
+        SubFolderName: string
+    }
 
 let IsUrl(str: string) : bool =
     str.Contains("://")
     || str.StartsWith("git@", StringComparison.OrdinalIgnoreCase)
 
-let isUrl = IsUrl firstArg
+let ExtractGhOwnerAndRepoNameFromUrl(maybeUrl: string) =
+    if not(IsUrl maybeUrl) then
+        failwith <| "Can't extract URL details from non-URL: " + maybeUrl
 
-// 1) Extract repo name from URL, or validate folder path
-let repoUrl, repoName, isExistingClone =
-    if isUrl then
-        let url = firstArg
+    let url = maybeUrl
 
-        let name =
-            let pathPart =
-                if url.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
-                    // SCP-style SSH URL: git@host:path/to/repo.git
-                    let colonIndex = url.IndexOf(':')
+    let pathPart =
+        if url.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
+            let colonIndex = url.IndexOf ':'
+            url.Substring(colonIndex + 1)
+        else
+            (Uri url).AbsolutePath.TrimStart '/'
 
-                    if colonIndex < 0 then
-                        failwith
-                            "Invalid SCP-style git URL: missing ':' separator"
+    let owner = pathPart.TrimEnd('/').Split('/').[0]
 
-                    url.Substring(colonIndex + 1)
-                else
-                    // Standard URI (https, ssh://, file://, etc.)
-                    let uri = Uri url
-                    uri.AbsolutePath
-
-            let segments = pathPart.TrimEnd('/').Split('/')
-            let lastSegmentOpt = Array.tryLast segments
-
-            match lastSegmentOpt with
-            | None -> failwith "Unreachable"
-            | Some lastSegment ->
-                if
-                    lastSegment.EndsWith
-                        (
-                            ".git",
-                            StringComparison.OrdinalIgnoreCase
-                        )
-                then
-                    lastSegment.Substring(0, lastSegment.Length - ".git".Length)
-                else
-                    lastSegment
-
-        let existing =
-            Directory.Exists name
-            && File.Exists(Path.Combine(name, ".git"))
-            && Directory.Exists(Path.Combine(name, ".bare"))
-
-        url, name, existing
-    else
-        let fullPath = Path.GetFullPath firstArg
-
-        if not(Directory.Exists fullPath) then
-            let exitCode, errMsg = ErrDirectoryDoesNotExist firstArg
-            Console.Error.WriteLine errMsg
-
-            Environment.Exit exitCode
-
-        let gitFile = Path.Combine(fullPath, ".git")
-        let bareDir = Path.Combine(fullPath, ".bare")
-
-        if not(File.Exists gitFile) || not(Directory.Exists bareDir) then
-            let exitCode, errMsg = ErrDirectoryIsNotClone firstArg
-            Console.Error.WriteLine errMsg
-
-            Environment.Exit exitCode
-
-        let name = Path.GetFileName(Path.TrimEndingDirectorySeparator fullPath)
-
-        String.Empty, name, true
-
-let ghOwner =
-    if isUrl then
+    let repoName =
         let pathPart =
-            if repoUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
-                let colonIndex = repoUrl.IndexOf ':'
-                repoUrl.Substring(colonIndex + 1)
-            else
-                (Uri repoUrl).AbsolutePath.TrimStart '/'
+            if url.StartsWith("git@", StringComparison.OrdinalIgnoreCase) then
+                // SCP-style SSH URL: git@host:path/to/repo.git
+                let colonIndex = url.IndexOf(':')
 
-        pathPart.TrimEnd('/').Split('/').[0]
-    else
-        String.Empty
+                if colonIndex < 0 then
+                    failwith "Invalid SCP-style git URL: missing ':' separator"
+
+                url.Substring(colonIndex + 1)
+            else
+                // Standard URI (https, ssh://, file://, etc.)
+                let uri = Uri url
+                uri.AbsolutePath
+
+        let segments = pathPart.TrimEnd('/').Split('/')
+        let lastSegmentOpt = Array.tryLast segments
+
+        match lastSegmentOpt with
+        | None -> failwith "Unreachable"
+        | Some lastSegment ->
+            if lastSegment.EndsWith(".git", StringComparison.OrdinalIgnoreCase) then
+                lastSegment.Substring(0, lastSegment.Length - ".git".Length)
+            else
+                lastSegment
+
+    (owner, repoName)
 
 let CheckIsGitHubFork (owner: string) (repo: string) : Option<bool> =
     use httpClient = new System.Net.Http.HttpClient()
@@ -165,64 +134,35 @@ let CheckIsGitHubFork (owner: string) (repo: string) : Option<bool> =
     with
     | _ -> None
 
-// Check branch existence on remote only when a URL was given
-let remoteBranchExists =
-    if not isUrl then
-        false
-    else
-        let output =
-            Process
-                .Execute(
-                    {
-                        Command = "git"
-                        Arguments =
-                            sprintf "ls-remote --heads %s %s" repoUrl branchName
-                    },
-                    Echo.Off
-                )
-                .UnwrapDefault()
-                .Trim()
 
-        output.Contains branchName
-
-// 2) Handle directory creation or validate existing clone
-if not isExistingClone then
-    Directory.CreateDirectory repoName |> ignore<DirectoryInfo>
-
-// 3) cd into that folder
-let targetDir =
-    if isUrl then
-        repoName
-    else
-        firstArg
-
-Directory.SetCurrentDirectory targetDir
-
-// Determine branch existence after entering the directory
-let branchExists =
-    if isUrl then
-        remoteBranchExists
-    else
-        let localCheck =
-            Process.Execute(
+// Determine branch existence via ls-remote against a single remote target (name or URL)
+let CheckRemoteBranchExists branchName remote =
+    let output =
+        Process
+            .Execute(
                 {
                     Command = "git"
                     Arguments =
-                        sprintf
-                            "rev-parse --verify --quiet refs/heads/%s"
-                            branchName
+                        sprintf "ls-remote --heads %s %s" remote branchName
                 },
                 Echo.Off
             )
+            .UnwrapDefault()
+            .Trim()
 
-        match localCheck.Result with
-        | Error _ -> false
-        | WarningsOrAmbiguous _
-        | Success _ -> true
+    output.Contains branchName
 
-if isExistingClone then
-    if isUrl then
-        // Check if repoUrl is already a remote
+let AllRemotes initialState =
+    match initialState with
+    | {
+          ArgType = Url _
+          AlreadyCloned = false
+          RepoAndFolderName = repoName
+      } when (not(Directory.Exists(Path.Combine(initialDir, repoName)))) ->
+        failwithf
+            "BUG: can't check remotes if repo is not cloned yet to %s"
+            (Path.Combine(initialDir, repoName))
+    | _ ->
         let remoteOutput =
             Process
                 .Execute(
@@ -234,120 +174,165 @@ if isExistingClone then
                 )
                 .UnwrapDefault()
 
-        let remoteAlreadyExists =
-            Misc.CrossPlatformStringSplitInLines remoteOutput
-            |> Seq.exists(fun line -> line.Contains repoUrl)
-
-        if not remoteAlreadyExists then
-            let existingRemotes =
-                Misc.CrossPlatformStringSplitInLines remoteOutput
-                |> Seq.choose(fun line ->
-                    let trimmed = line.Trim()
-
-                    if String.IsNullOrEmpty trimmed then
-                        None
-                    else
-                        let parts =
-                            trimmed.Split(
-                                [| ' '; '\t' |],
-                                StringSplitOptions.RemoveEmptyEntries
-                            )
-
-                        if parts.Length > 0 then
-                            Some parts.[0]
-                        else
-                            None
-                )
-                |> Seq.distinct
-                |> Seq.toList
-
-            let isGitHubUrl =
-                repoUrl.Contains(
-                    "github.com",
-                    StringComparison.OrdinalIgnoreCase
+        Misc.CrossPlatformStringSplitInLines remoteOutput
+        |> Seq.map(fun line -> line.Trim())
+        |> Seq.filter(fun trimmed -> not(String.IsNullOrEmpty trimmed))
+        |> Seq.choose(fun trimmed ->
+            let parts =
+                trimmed.Split(
+                    [| ' '; '\t' |],
+                    StringSplitOptions.RemoveEmptyEntries
                 )
 
-            let remoteName =
-                if not isGitHubUrl then
+            if parts.Length >= 2 then
+                Some(parts.[0], parts.[1])
+            else
+                None
+        )
+        |> Seq.distinctBy fst
+        |> Map.ofSeq
+
+let (initialState, branchTargetInfo): (InitialState * BranchTargetInfo) =
+    let args = Misc.FsxOnlyArguments()
+
+    if args.Length <> 2 then
+        let exitCode, errMsg = errUsage
+        Console.Error.WriteLine errMsg
+
+        Environment.Exit exitCode
+
+    let firstArg = args.[0]
+    let branchName = args.[1]
+
+    // Sanitize branch name for use as a folder name by replacing slashes/backslashes with dashes
+    let branchFolderName = branchName.Replace('/', '-').Replace('\\', '-')
+
+    let firstArgIsUrl = IsUrl firstArg
+
+    let alreadyCloned, argType, repoAndFolderName =
+        if firstArgIsUrl then
+            let owner, repoAndFolderName =
+                ExtractGhOwnerAndRepoNameFromUrl firstArg
+
+            let existing = Directory.Exists repoAndFolderName
+
+            if existing then
+                if (not(File.Exists(Path.Combine(repoAndFolderName, ".git"))))
+                   || (not(
+                       Directory.Exists(
+                           Path.Combine(repoAndFolderName, ".bare")
+                       )
+                   )) then
                     let exitCode, errMsg =
-                        ErrNotGitHubCannotDetermineRemoteName repoName
+                        ErrDirectoryIsNotClone repoAndFolderName
 
                     Console.Error.WriteLine errMsg
                     Environment.Exit exitCode
-                    failwith <| "Unreachable because of: " + errMsg
-                else
-                    match CheckIsGitHubFork ghOwner repoName with
-                    | Some false ->
-                        if not(List.contains "upstream" existingRemotes) then
-                            "upstream"
-                        elif not(List.contains "origin" existingRemotes) then
-                            "origin"
-                        else
-                            let exitCode, errMsg = errCannotDetermineRemoteName
-                            Console.Error.WriteLine errMsg
 
-                            Environment.Exit exitCode
-                            failwith <| "Unreachable because of: " + errMsg
-                    | Some true -> sprintf "%sFork" ghOwner
-                    | None ->
-                        let exitCode, errMsg = errCannotCheckGitHubFork
-                        Console.Error.WriteLine errMsg
+            if not existing then
+                Directory.CreateDirectory repoAndFolderName
+                |> ignore<DirectoryInfo>
 
-                        Environment.Exit exitCode
-                        failwith <| "Unreachable because of: " + errMsg
-
-            let addRemoteProc =
-                Process.Execute(
+            let headBranch =
+                let gitSymbolicRemoteRef =
                     {
                         Command = "git"
                         Arguments =
-                            sprintf "remote add %s %s" remoteName repoUrl
-                    },
-                    Echo.All
-                )
+                            sprintf "ls-remote --symref %s HEAD" firstArg
+                    }
 
-            match addRemoteProc.Result with
-            | Error _ ->
-                let exitCode, errMsg = ErrFailedToAddRemote repoUrl
+                // the split game below is meant to extract "master" from this example output:
+                //     ref: refs/heads/master\tHEAD
+                //     d2f140d0d...\tHEAD
+                Process
+                    .Execute(gitSymbolicRemoteRef, Echo.Off)
+                    .UnwrapDefault()
+                    .Trim()
+                    // FIXME: this parsing logic would be broken in case there's a head branch with a slash in its name,
+                    //        but that would be a very weird naming for a head branch, so let's consider this an edge case
+                    .Split(
+                        '/'
+                    )
+                    .Last()
+                    .Split('\t')
+                    .First()
+
+            existing, Url(firstArg, owner, headBranch), repoAndFolderName
+        else
+            let fullPath = Path.GetFullPath firstArg
+
+            if not(Directory.Exists fullPath) then
+                let exitCode, errMsg = ErrDirectoryDoesNotExist firstArg
                 Console.Error.WriteLine errMsg
 
                 Environment.Exit exitCode
-            | WarningsOrAmbiguous _
-            | Success _ -> ()
 
-    // Fetch all remotes
-    let fetchProc =
-        Process.Execute(
-            {
-                Command = "git"
-                Arguments = "fetch --all"
-            },
-            Echo.All
-        )
+            let gitFile = Path.Combine(fullPath, ".git")
+            let bareDir = Path.Combine(fullPath, ".bare")
 
-    match fetchProc.Result with
-    | Error _ ->
-        let exitCode, errMsg = errGitFetchAllFailed
-        Console.Error.WriteLine errMsg
-        Environment.Exit exitCode
-    | WarningsOrAmbiguous _
-    | Success _ -> ()
-else
-    let cloneSpecificSingleBranch =
-        if branchExists then
-            sprintf "--branch %s" branchName
-        else
-            String.Empty
+            if not(File.Exists gitFile) || not(Directory.Exists bareDir) then
+                let exitCode, errMsg = ErrDirectoryIsNotClone firstArg
+                Console.Error.WriteLine errMsg
 
-    // 4) git clone --single-branch --bare <repository-url> .bare
+                Environment.Exit exitCode
+
+            true, FolderName, firstArg
+
+    let initialState =
+        {
+            RepoAndFolderName = repoAndFolderName
+            ArgType = argType
+            AlreadyCloned = alreadyCloned
+        }
+
+    Directory.SetCurrentDirectory initialState.RepoAndFolderName
+
+    let branchExists =
+        let existsOnConfiguredRemotes() =
+            AllRemotes initialState
+            |> Map.toSeq
+            |> Seq.map fst
+            |> Seq.exists(CheckRemoteBranchExists branchName)
+
+        match initialState with
+        | {
+              ArgType = Url(fullUrl, _owner, _headBranch)
+              AlreadyCloned = false
+          } -> CheckRemoteBranchExists branchName fullUrl
+        | {
+              ArgType = Url(fullUrl, _owner, _headBranch)
+              AlreadyCloned = true
+          } ->
+            CheckRemoteBranchExists branchName fullUrl
+            || existsOnConfiguredRemotes()
+        | {
+              ArgType = FolderName
+              AlreadyCloned = true
+          } -> existsOnConfiguredRemotes()
+        | {
+              ArgType = FolderName
+              AlreadyCloned = false
+          } -> false
+
+    let branchTargetInfo =
+        {
+            Name = branchName
+            SubFolderName = branchFolderName
+            ExistsAlready = branchExists
+        }
+
+    initialState, branchTargetInfo
+
+match initialState with
+| {
+      ArgType = Url(fullUrl, owner, _headBranch)
+      AlreadyCloned = false
+      RepoAndFolderName = repoAndFolderName
+  } ->
     let gitClone =
         {
             Command = "git"
-            Arguments =
-                sprintf
-                    "clone --single-branch %s --bare -- %s .bare"
-                    cloneSpecificSingleBranch
-                    repoUrl
+            Arguments = sprintf "clone --single-branch --bare %s .bare" fullUrl
         }
 
     let cloneProc = Process.Execute(gitClone, Echo.All)
@@ -355,82 +340,30 @@ else
     match cloneProc.Result with
     | Error _ ->
         // Clean up the directory we created
-        Directory.SetCurrentDirectory("..")
-        Directory.Delete(repoName, true)
+        Directory.SetCurrentDirectory initialDir
+        Directory.Delete(repoAndFolderName, true)
         let exitCode, errMsg = errGitCloneFailed
         Console.Error.WriteLine errMsg
         Environment.Exit exitCode
     | WarningsOrAmbiguous _
     | Success _ -> ()
 
-    // 5) Create .git file pointing to ./.bare (using F# instead of echo)
+    // Create .git file pointing to ./.bare (using F# instead of echo)
     File.WriteAllText(".git", "gitdir: ./.bare" + Environment.NewLine)
 
-// 6) Find default branch
-let gitSymbolicRef =
-    {
-        Command = "git"
-        Arguments = "symbolic-ref HEAD --short"
-    }
-
-let baseBranch =
-    if branchExists then
-        branchName
-    else
-        Process
-            .Execute(gitSymbolicRef, Echo.Off)
-            .UnwrapDefault()
-            .Trim()
-
-// 7) git worktree add
-let gitWorktreeAdd =
-    if branchExists then
-        {
-            Command = "git"
-            Arguments = sprintf "worktree add %s %s" branchFolderName baseBranch
-        }
-    else
-        {
-            Command = "git"
-            Arguments =
-                sprintf "worktree add -b %s %s" branchName branchFolderName
-        }
-
-let worktreeProc = Process.Execute(gitWorktreeAdd, Echo.All)
-
-match worktreeProc.Result with
-| Error _ ->
-    let exitCode, errMsg = errGitWorktreeAddFailed
-    Console.Error.WriteLine errMsg
-    Environment.Exit exitCode
-| WarningsOrAmbiguous _
-| Success _ -> ()
-
-// 8) cd into branchName
-Directory.SetCurrentDirectory branchFolderName
-
-Console.WriteLine(
-    sprintf
-        "Successfully created worktree '%s' from branch '%s' of repo '%s'"
-        baseBranch
-        branchName
-        repoName
-)
-
-// 9) If repo is a GitHub fork, rename 'origin' remote to '<owner>Fork'
-if not isExistingClone then
     let isGitHubUrl =
-        repoUrl.Contains("github.com", StringComparison.OrdinalIgnoreCase)
+        fullUrl.Contains("github.com", StringComparison.OrdinalIgnoreCase)
 
+    // If repo is a GitHub fork, rename 'origin' remote to '<owner>Fork'
     if isGitHubUrl then
-        match CheckIsGitHubFork ghOwner repoName with
+        match CheckIsGitHubFork owner repoAndFolderName with
         | None ->
             Console.Error.WriteLine(
                 "Could not check whether the repo is a GitHub fork. Skipping remote rename."
             )
         | Some isFork ->
             if isFork then
-                let newRemoteName = sprintf "%sFork" ghOwner
+                let newRemoteName = sprintf "%sFork" owner
                 let renameArgs = sprintf "remote rename origin %s" newRemoteName
 
                 let gitRemoteRename =
@@ -449,3 +382,189 @@ if not isExistingClone then
                     Environment.Exit exitCode
                 | WarningsOrAmbiguous _
                 | Success _ -> ()
+
+| {
+      ArgType = Url(fullUrl, owner, _headBranch)
+      AlreadyCloned = true
+      RepoAndFolderName = repoAndFolderName
+  } ->
+    let maybeFoundRemote =
+        AllRemotes initialState
+        |> Map.tryPick(fun name url ->
+            if url.Contains fullUrl then
+                Some name
+            else
+                None
+        )
+
+    match maybeFoundRemote with
+    | Some _ -> ()
+    | None ->
+        let isGitHubUrl =
+            fullUrl.Contains("github.com", StringComparison.OrdinalIgnoreCase)
+
+        let newRemoteName =
+            if not isGitHubUrl then
+                let exitCode, errMsg =
+                    ErrNotGitHubCannotDetermineRemoteName repoAndFolderName
+
+                Console.Error.WriteLine errMsg
+                Environment.Exit exitCode
+                failwith <| "Unreachable because of: " + errMsg
+            else
+                let remoteMap = AllRemotes initialState
+
+                match CheckIsGitHubFork owner repoAndFolderName with
+                | Some false ->
+                    if not(Map.containsKey "upstream" remoteMap) then
+                        "upstream"
+                    elif not(Map.containsKey "origin" remoteMap) then
+                        "origin"
+                    else
+                        let exitCode, errMsg = errCannotDetermineRemoteName
+
+                        Console.Error.WriteLine errMsg
+
+                        Environment.Exit exitCode
+                        failwith <| "Unreachable because of: " + errMsg
+                | Some true -> sprintf "%sFork" owner
+                | None ->
+                    let exitCode, errMsg = errCannotCheckGitHubFork
+                    Console.Error.WriteLine errMsg
+
+                    Environment.Exit exitCode
+                    failwith <| "Unreachable because of: " + errMsg
+
+        let addRemoteProc =
+            Process.Execute(
+                {
+                    Command = "git"
+                    Arguments = sprintf "remote add %s %s" newRemoteName fullUrl
+                },
+                Echo.All
+            )
+
+        match addRemoteProc.Result with
+        | Error _ ->
+            let exitCode, errMsg = ErrFailedToAddRemote fullUrl
+            Console.Error.WriteLine errMsg
+
+            Environment.Exit exitCode
+        | WarningsOrAmbiguous _
+        | Success _ -> ()
+| _ -> ()
+
+// Ensure the target branch (and head branch, in case we want to rebase) are
+// included in fetch refspec if it exists on remote
+if branchTargetInfo.ExistsAlready then
+    let branchesToFetch =
+        let headBranchOpt =
+            match initialState with
+            | {
+                  ArgType = Url(_fullUrl, _owner, headBranch)
+                  AlreadyCloned = _
+                  RepoAndFolderName = _
+              } -> Some headBranch
+            | _ ->
+                let result =
+                    Process.Execute(
+                        {
+                            Command = "git"
+                            Arguments = "symbolic-ref --short HEAD"
+                        },
+                        Echo.Off
+                    )
+
+                match result.Result with
+                | Error _ -> None
+                | WarningsOrAmbiguous _
+                | Success _ -> Some(result.UnwrapDefault().Trim())
+
+        match headBranchOpt with
+        | Some headBranch -> [ headBranch; branchTargetInfo.Name ]
+        | None -> List.singleton branchTargetInfo.Name
+
+    let allRemoteNames =
+        AllRemotes initialState |> Map.toSeq |> Seq.map fst |> Seq.toList
+
+    allRemoteNames
+    |> Seq.iter(fun remoteName ->
+        for branchToFetch in branchesToFetch do
+            if CheckRemoteBranchExists branchToFetch remoteName then
+                let gitCmd =
+                    sprintf
+                        "remote set-branches --add %s %s"
+                        remoteName
+                        branchToFetch
+
+                let setBranchesProc =
+                    Process.Execute(
+                        {
+                            Command = "git"
+                            Arguments = gitCmd
+                        },
+                        Echo.All
+                    )
+
+                match setBranchesProc.Result with
+                | Error(_exitCode, output) ->
+                    Console.Error.WriteLine(output.ToString())
+                    failwithf "Command 'git %s' failed" gitCmd
+                | _ -> ()
+    )
+
+// Fetch all remotes
+let fetchProc =
+    Process.Execute(
+        {
+            Command = "git"
+            Arguments = "fetch --all"
+        },
+        Echo.All
+    )
+
+match fetchProc.Result with
+| Error _ ->
+    let exitCode, errMsg = errGitFetchAllFailed
+    Console.Error.WriteLine errMsg
+    Environment.Exit exitCode
+| WarningsOrAmbiguous _
+| Success _ -> ()
+
+let gitWorktreeAddArgs =
+    if branchTargetInfo.ExistsAlready then
+        sprintf "%s %s" branchTargetInfo.SubFolderName branchTargetInfo.Name
+    else
+        sprintf "-b %s %s" branchTargetInfo.Name branchTargetInfo.SubFolderName
+
+let cmd =
+    {
+        Command = "git"
+        Arguments = sprintf "worktree add %s" gitWorktreeAddArgs
+    }
+
+let worktreeProc = Process.Execute(cmd, Echo.All)
+
+match worktreeProc.Result with
+| Error _ ->
+    let exitCode, errMsg = errGitWorktreeAddFailed
+    Console.Error.WriteLine errMsg
+    Environment.Exit exitCode
+| WarningsOrAmbiguous _
+| Success _ -> ()
+
+if branchTargetInfo.ExistsAlready then
+    Console.WriteLine(
+        sprintf
+            "Successfully created worktree '%s' from branch '%s' of repo '%s'"
+            branchTargetInfo.SubFolderName
+            branchTargetInfo.Name
+            initialState.RepoAndFolderName
+    )
+else
+    Console.WriteLine(
+        sprintf
+            "Successfully created worktree '%s' from base branch of repo '%s'"
+            branchTargetInfo.SubFolderName
+            initialState.RepoAndFolderName
+    )

--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -624,35 +624,20 @@ match worktreeProc.Result with
 | Success _ -> ()
 
 // If branch already existed, worktree was created from a remote tracking ref
-// and is in detached HEAD state; create a local branch (unless it already exists,
-// e.g. from a bare clone)
+// and is in detached HEAD state; create or reset the local branch to HEAD
+// (which is the latest remote tracking ref), then switch to it
 if branchTargetInfo.ExistsAlready then
-    let branchAlreadyExists =
-        Process
-            .Execute(
-                {
-                    Command = "git"
-                    Arguments = sprintf "branch --list %s" branchTargetInfo.Name
-                },
-                Echo.Off
-            )
-            .UnwrapDefault()
-            .Trim()
-            .Length > 0
+    let fullCmd =
+        sprintf
+            "git -C %s checkout -B %s"
+            branchTargetInfo.SubFolderName
+            branchTargetInfo.Name
 
     let checkoutProc =
         Process.Execute(
             {
-                Command = "git"
-                Arguments =
-                    sprintf
-                        "-C %s checkout %s%s"
-                        branchTargetInfo.SubFolderName
-                        (if branchAlreadyExists then
-                             ""
-                         else
-                             "-b ")
-                        branchTargetInfo.Name
+                Command = fullCmd.Split(' ').First()
+                Arguments = fullCmd.Substring("git ".Length)
             },
             Echo.All
         )

--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -624,16 +624,34 @@ match worktreeProc.Result with
 | Success _ -> ()
 
 // If branch already existed, worktree was created from a remote tracking ref
-// and is in detached HEAD state; create a local branch
+// and is in detached HEAD state; create a local branch (unless it already exists,
+// e.g. from a bare clone)
 if branchTargetInfo.ExistsAlready then
+    let branchAlreadyExists =
+        Process
+            .Execute(
+                {
+                    Command = "git"
+                    Arguments = sprintf "branch --list %s" branchTargetInfo.Name
+                },
+                Echo.Off
+            )
+            .UnwrapDefault()
+            .Trim()
+            .Length > 0
+
     let checkoutProc =
         Process.Execute(
             {
                 Command = "git"
                 Arguments =
                     sprintf
-                        "-C %s checkout -b %s"
+                        "-C %s checkout %s%s"
                         branchTargetInfo.SubFolderName
+                        (if branchAlreadyExists then
+                             ""
+                         else
+                             "-b ")
                         branchTargetInfo.Name
             },
             Echo.All

--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -623,7 +623,30 @@ match worktreeProc.Result with
 | WarningsOrAmbiguous _
 | Success _ -> ()
 
+// If branch already existed, worktree was created from a remote tracking ref
+// and is in detached HEAD state; create a local branch
 if branchTargetInfo.ExistsAlready then
+    let checkoutProc =
+        Process.Execute(
+            {
+                Command = "git"
+                Arguments =
+                    sprintf
+                        "-C %s checkout -b %s"
+                        branchTargetInfo.SubFolderName
+                        branchTargetInfo.Name
+            },
+            Echo.All
+        )
+
+    match checkoutProc.Result with
+    | Error _ ->
+        let exitCode, errMsg = errGitCheckoutFailed
+        Console.Error.WriteLine errMsg
+        Environment.Exit exitCode
+    | WarningsOrAmbiguous _
+    | Success _ -> ()
+
     Console.WriteLine(
         sprintf
             "Successfully created worktree '%s' from branch '%s' of repo '%s'"

--- a/scripts/cloneWorkTree.fsx
+++ b/scripts/cloneWorkTree.fsx
@@ -533,7 +533,77 @@ match fetchProc.Result with
 
 let gitWorktreeAddArgs =
     if branchTargetInfo.ExistsAlready then
-        sprintf "%s %s" branchTargetInfo.SubFolderName branchTargetInfo.Name
+        // Use remote tracking ref to avoid ambiguity when multiple remotes have the same branch
+        let allRemoteNames =
+            AllRemotes initialState |> Map.toSeq |> Seq.map fst |> Seq.toList
+
+        let remotesWithBranch =
+            allRemoteNames
+            |> List.filter(fun remoteName ->
+                CheckRemoteBranchExists branchTargetInfo.Name remoteName
+            )
+
+        // Prefer: input-URL remote > upstream/origin > non-fork remotes
+        // TODO: improve this heuristic — consider checking which branch has more commits,
+        // or which branch's latest commit is more recent
+        let preferredRemote =
+            match remotesWithBranch with
+            | [] -> None // fallback
+            | singleRemote :: [] -> Some singleRemote
+            | _multipleRemotes ->
+                // Determine which remote corresponds to the input URL (if first arg was a URL)
+                let inputUrlRemote =
+                    match initialState with
+                    | {
+                          ArgType = Url(fullUrl, _, _)
+                      } ->
+                        AllRemotes initialState
+                        |> Map.tryPick(fun name url ->
+                            if url.Contains fullUrl then
+                                Some name
+                            else
+                                None
+                        )
+                    | _ -> None
+
+                let fromInputUrl =
+                    inputUrlRemote
+                    |> Option.bind(fun urlRemote ->
+                        remotesWithBranch
+                        |> List.tryFind(fun name -> name = urlRemote)
+                    )
+
+                fromInputUrl
+                |> Option.orElseWith(fun () ->
+                    remotesWithBranch
+                    |> List.tryFind(fun name -> name = "upstream")
+                )
+                |> Option.orElseWith(fun () ->
+                    remotesWithBranch
+                    |> List.tryFind(fun name -> name = "origin")
+                )
+                |> Option.orElseWith(fun () ->
+                    remotesWithBranch
+                    |> List.tryFind(fun name ->
+                        not(
+                            name.EndsWith(
+                                "Fork",
+                                StringComparison.OrdinalIgnoreCase
+                            )
+                        )
+                    )
+                )
+                |> Option.orElse(List.tryHead remotesWithBranch)
+
+        match preferredRemote with
+        | Some remote ->
+            sprintf
+                "%s %s/%s"
+                branchTargetInfo.SubFolderName
+                remote
+                branchTargetInfo.Name
+        | None ->
+            sprintf "%s %s" branchTargetInfo.SubFolderName branchTargetInfo.Name
     else
         sprintf "-b %s %s" branchTargetInfo.Name branchTargetInfo.SubFolderName
 

--- a/src/FileConventions/Library.fs
+++ b/src/FileConventions/Library.fs
@@ -543,7 +543,8 @@ let allowedNonVerboseFlags =
     seq {
         "unzip"
 
-        // git
+        "git -C"
+        // more from git:
         "checkout -b"
         "worktree add -b"
 


### PR DESCRIPTION
Fixes #292

## Problem

When `cloneWorkTree.fsx` is run on an existing clone to add a worktree for a branch that exists remotely but hasn't been fetched yet, `git fetch --all` would not pull the branch because the bare clone's fetch refspec only includes the default branch. As a result, `git worktree add` would create a worktree pointing to a local ref that was absent or outdated, effectively checking out the default branch (`main`) instead of the requested remote branch.

## Fix

Before `git fetch --all`, run `git remote set-branches --add <remote> <branchName>` on all remotes to ensure the branch is included in the fetch refspec. This ensures the remote branch is actually fetched, so `git worktree add <folder> <branch>` correctly checks out the intended branch.

## Refactoring

Removed the separate `remoteBranchExists` variable and consolidated branch checking into a single `branchExists` binding:
- For existing clones: check all configured remotes via `git ls-remote`
- For new clones: check the provided URL via `git ls-remote`

This eliminates the split between `isUrl`/`isExistingClone` logic for branch checks and ensures there's only one conceptual invocation of `git ls-remote`.

## Updates

Addressed the TODO regarding `headBranch` for `FolderName` arguments: when the first argument is a local folder path rather than a URL, the script now queries the current default branch via `git symbolic-ref --short HEAD` and includes it in the fetch refspec alongside the requested branch. If the query fails (e.g., detached HEAD), it gracefully falls back to fetching only the target branch.