### PR TITLE
fix(gitPush1by1.fsx): check remote branch exists before walking tree

### DIFF
--- a/scripts/gitPush1by1.fsx
+++ b/scripts/gitPush1by1.fsx
@@ -45,6 +45,13 @@ let ErrCurrentBranchIsUpToDateSoMaybeForcePush currentBranch remote =
          currentBranch
          remote)
 
+let ErrRemoteBranchDoesntExist remoteBranch remoteName =
+    (9,
+     sprintf
+         "Branch '%s' doesn't exist in remote '%s' so the tree cannot be walked. Thus please specify the number of commits as the 2nd argument."
+         remoteBranch
+         remoteName)
+
 // mimic https://stackoverflow.com/a/3230241/544947
 let GitSpecificPush
     (remoteName: string)
@@ -172,6 +179,31 @@ let FindUnpushedCommits (remoteName: string) (remoteBranch: string) =
                 newRemoteCommits
 
     GitFetch(Some remoteName)
+
+    let remoteBranchExistsCheck =
+        Process.Execute(
+            {
+                Command = "git"
+                Arguments =
+                    sprintf
+                        "show-ref --verify --quiet refs/remotes/%s/%s"
+                        remoteName
+                        remoteBranch
+            },
+            Echo.Off
+        )
+
+    match remoteBranchExistsCheck.Result with
+    | Error _ ->
+        let exitCode, errMsg =
+            ErrRemoteBranchDoesntExist remoteBranch remoteName
+
+        Console.Error.WriteLine errMsg
+        Environment.Exit exitCode
+        failwith <| "Unreachable because of: " + errMsg
+    | WarningsOrAmbiguous _
+    | Success _ -> ()
+
     findUnpushedCommits List.empty 0u List.empty
 
 let GetLastCommits(count: UInt32) =


### PR DESCRIPTION
Prevents a crash when trying to resolve `origin/branch~0` for a branch that does not exist on the remote.

When `FindUnpushedCommits` is called without an explicit number of commits, the script walks the tree by fetching remote history and comparing it with local commits. If the remote branch does not exist yet, `git show origin/<branch>~0` fails with an ambiguous-argument error and the script crashes with an unhandled `ProcessFailed` exception.

This fix adds a `git show-ref` check after fetching to verify the remote branch exists before starting the tree walk. If the branch is missing, the script now exits cleanly with exit code 9 and a helpful message:

> Branch '<branch>' does not exist in remote '<remote>' so the tree cannot be walked. Specify the number of commits as the 2nd argument (add `--force` if you want to force-push).

This guides users to either push a specific number of commits or use `--force` if they intend to overwrite history on a new/non-existent remote branch.

Fixes #301