### PR TITLE
GitHubCI: try fix auto-comment again

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,11 +9,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-# needed for this workflow itself can post comments in the PR if it spawned from PR
-permissions:
-  issues: write
-  pull-requests: write
-
 env:
   DOTNET_VERSION: "10.0"
   # As we use .NET>6 now, to run tools compiled for .NETv6 we need to set roll-forward to major
@@ -291,43 +286,3 @@ jobs:
       - name: Check commits 1 by 1
         if: github.event_name == 'pull_request'
         run: ./scripts/checkCommits1by1.fsx
-
-  # TODO: maybe move this job to be a workflow on its own? this way we would not
-  # need to hardcode all job names twice in the `needs` and `if` elements
-  ci-pr-failure-comment:
-    needs:
-      [
-        build-fs,
-        file-conventions-tests,
-        build-ts,
-        commitlint-plugins-tests,
-        sanity-check,
-      ]
-    if: |
-      always() && github.event_name == 'pull_request' &&
-      github.event.pull_request.user.login == 'nodefect' &&
-      (
-        needs.build-fs.result == 'failure' ||
-        needs.file-conventions-tests.result == 'failure' ||
-        needs.build-ts.result == 'failure' ||
-        needs.commitlint-plugins-tests.result == 'failure' ||
-        needs.sanity-check.result == 'failure'
-      )
-    runs-on: ubuntu-latest
-    container:
-      image: "ubuntu:26.04"
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Comment on PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '⚠️ **CI Build Failed!**\n\nHey @' +
-                context.payload.pull_request.user.login +
-                ', one or more CI jobs failed. Please check the workflow logs.'
-            })

--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -1,0 +1,42 @@
+name: CI Failure Comment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment-on-failure:
+    # Only run if the CI workflow failed and the PR author is nodefect
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.actor.login == 'nodefect'
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        env:
+          WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        with:
+          script: |
+            const prs = context.payload.workflow_run.pull_requests;
+            if (!prs || prs.length === 0) {
+              console.log('No PR associated with this workflow run, skipping.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: prs[0].number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ **CI Build Failed!**\n\nHey @' +
+                context.payload.workflow_run.actor.login +
+                ', one or more CI jobs failed. Please check the [workflow logs](' +
+                context.payload.workflow_run.html_url + ').'
+            });


### PR DESCRIPTION
Split the auto-comment logic into a separate workflow (ci-failure-comment.yml) triggered by workflow_run, replacing the inline ci-pr-failure-comment job.

Root cause: pull_request events from forks receive a read-only GITHUB_TOKEN regardless of declared permissions. This is a GitHub security restriction that prevents posting comments via the API (403 "Resource not accessible by integration"). The top-level `permissions:` block had no effect for fork PRs.

The fix:
- Removed ci-pr-failure-comment job and top-level permissions block from CI.yml.
- Added ci-failure-comment.yml using the workflow_run event, which runs in the base repo context and inherits full GITHUB_TOKEN permissions.
- The new workflow checks workflow_run.conclusion == "failure" (equivalent to the original "any dependent job failed" condition) and posts the comment.