### PR TITLE
fix(ci-failure-comment): handle fork PRs where commit SHA is not in base repo

### DIFF
--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -30,7 +30,7 @@ jobs:
             if (prs && prs.length > 0) {
               pr = prs[0];
             } else {
-              // Fallback for fork PRs where workflow_run.pull_requests is empty
+              // Fallback 1: query API by commit SHA (works for same-repo PRs)
               const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -38,6 +38,22 @@ jobs:
               });
               if (pulls.length > 0) {
                 pr = pulls[0];
+              } else {
+                // Fallback 2: list open PRs by head repo + branch (works for fork PRs
+                // because the commit SHA may not exist in the base repo)
+                const headRepo = context.payload.workflow_run.head_repository;
+                const headBranch = context.payload.workflow_run.head_branch;
+                if (headRepo && headBranch) {
+                  const { data: pulls } = await github.rest.pulls.list({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    state: 'open',
+                    head: `${headRepo.owner.login}:${headBranch}`
+                  });
+                  if (pulls.length > 0) {
+                    pr = pulls[0];
+                  }
+                }
               }
             }
 


### PR DESCRIPTION
The previous fix (PR #313) added a fallback that queries `repos.listPullRequestsAssociatedWithCommit` using the workflow run's `head_sha`. However, for PRs coming from forks, the commit SHA does not exist in the base repository, so this API call still returns empty results.

This fix adds a second fallback that uses `pulls.list` with the `head` parameter (format: `forkOwner:branchName`) to find the associated PR. This works because the PR metadata in the base repo always tracks the fork owner and branch name, even when the commit itself is not present in the base repo.

Fixes #316