### PR TITLE
CI,Dockerfile: document docker better & rm sudo

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -254,12 +254,12 @@ jobs:
         run: |
           # We need this step so we can change the files using `npx prettier --write` in the next step.
           # Otherwise we get permission denied error in the CI.
-          sudo chmod 777 --recursive .
+          chmod 777 --recursive .
       - name: Install prettier
         run: npm install --verbose
       - name: Run "prettier" to check the style of our TypeScript and YML code
         run: |
-          sudo npm run format
+          npm run format
           # Since we changed file modes in the previous step we need the following command to
           # make git ignore mode changes in files and doesn't include them in the git diff command.
           git config core.fileMode false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,22 @@
 FROM ubuntu:26.04
 
-RUN apt update && \
-    apt install --yes --no-install-recommends \
-        sudo \
-        git \
-        ca-certificates \
-        dotnet-sdk-10.0 \
-        npm \
-        curl && \
-    npm install --global yarn && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt --yes update
+
+RUN apt --yes install --no-install-recommends git
+
+# We need to install `ca-certificates`, otherwise we get these errors in the CI:
+# Unable to load the service index for source https://api.nuget.org/v3/index.json.
+# The SSL connection could not be established, see inner exception.
+# The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot
+RUN apt --yes install --no-install-recommends ca-certificates
+
+RUN apt --yes install --no-install-recommends dotnet-sdk-10.0
+
+# commitlint depends on npm and yarn
+RUN apt --yes install --no-install-recommends npm
+RUN npm install --global yarn
+
+# cleanup apt cache to reduce img size & avoid unneeded files in the final layer
+RUN rm -rf /var/lib/apt/lists/*
 
 CMD ["bash"]


### PR DESCRIPTION
PR319[1] modified CI to be Docker-based, but swallowed all the
comments above installation commands; let's bring them back this
way. Also, it seems sudo is actually not needed because when
removing it (from CI & Dockerfile) everything still works.

[1] 18acc72f0b4001ff6d1094a45aadf52a008bc871
