### PR TITLE
fix(newTree.fsx): crash if remote branch disappears

### DIFF
--- a/scripts/newTree.fsx
+++ b/scripts/newTree.fsx
@@ -697,29 +697,56 @@ allRemoteNames
             CheckRemoteBranchExists cloneDir branch remoteName
         )
 
-    let setBranchesCmd =
-        let subCommand = "remote set-branches"
-        match existingBranches with
-        | [] ->
-            sprintf
-                "git -C %s %s %s"
-                cloneDir.FullPath
-                subCommand
-                remoteName
-        | branches ->
-            let branchesArg = String.Join(" ", branches)
+    let hasFetchRefspec =
+        try
+            Process
+                .ExecDefault(
+                    sprintf
+                        "git -C %s config --get-all remote.%s.fetch"
+                        cloneDir.FullPath
+                        remoteName,
+                    echo = Echo.Off
+                )
+                .UnwrapDefault()
+            |> ignore
+            true
+        with
+        | _ -> false
 
-            sprintf
-                "git -C %s %s %s %s"
-                cloneDir.FullPath
-                subCommand
-                remoteName
-                branchesArg
+    let maybeSetBranchesCmd =
+        match existingBranches, hasFetchRefspec with
+        | [], false -> None
+        | [], true ->
+            Some(
+                sprintf
+                    "git -C %s remote set-branches %s"
+                    cloneDir.FullPath
+                    remoteName
+            )
+        | branches, false ->
+            Some(
+                sprintf
+                    "git -C %s remote set-branches --add %s %s"
+                    cloneDir.FullPath
+                    remoteName
+                    (String.Join(" ", branches))
+            )
+        | branches, true ->
+            Some(
+                sprintf
+                    "git -C %s remote set-branches %s %s"
+                    cloneDir.FullPath
+                    remoteName
+                    (String.Join(" ", branches))
+            )
 
-    Process
-        .ExecDefault(setBranchesCmd)
-        .UnwrapDefault(throwWhenWarnings = false)
-    |> ignore<string>
+    match maybeSetBranchesCmd with
+    | None -> ()
+    | Some setBranchesCmd ->
+        Process
+            .ExecDefault(setBranchesCmd)
+            .UnwrapDefault(throwWhenWarnings = false)
+        |> ignore<string>
 )
 
 // Fetch all remotes

--- a/scripts/newTree.fsx
+++ b/scripts/newTree.fsx
@@ -358,6 +358,28 @@ let GetCurrentHeadBranch(cloneDir: AbsDir) =
         .UnwrapDefault(throwWhenWarnings = false)
         .Trim()
 
+let GetExistingWorktreeBranches(cloneDir: AbsDir) =
+    let output =
+        Process
+            .ExecDefault(
+                sprintf "git -C %s worktree list --porcelain" cloneDir.FullPath,
+                echo = Echo.Off
+            )
+            .UnwrapDefault()
+
+    Misc.CrossPlatformStringSplitInLines output
+    |> Seq.map(fun line -> line.Trim())
+    |> Seq.filter(fun trimmed -> not(String.IsNullOrEmpty trimmed))
+    |> Seq.choose(fun trimmed ->
+        let branchPrefix = "branch refs/heads/"
+        if trimmed.StartsWith branchPrefix then
+            Some(trimmed.Substring branchPrefix.Length)
+        else
+            None
+    )
+    |> Seq.distinct
+    |> Seq.toList
+
 let ValidateDirIsClone(cloneDir: AbsDir) =
     let gitFile =
         cloneDir.CombineFile(gitPointerFileName, checkExistence = false)
@@ -644,40 +666,61 @@ match initialState with
         |> ignore<string>
 | _ -> ()
 
-// Ensure the target branch (and head branch, in case we want to rebase) are
-// included in fetch refspec if it exists on remote
-if branchTargetInfo.ExistsAlready then
-    let branchesToFetch =
-        let headBranch =
-            match initialState with
-            | {
-                  ArgType = Url(_fullUrl, _owner, headBranch)
-                  AlreadyCloned = _
-                  RepoAndFolderName = _
-              } -> headBranch
-            | _ -> GetCurrentHeadBranch cloneDir
+// Collect all branches that should be tracked:
+// branches used by existing worktrees, the head branch, and the target branch.
+// Then reset each remote's branch tracking to only the branches that still
+// exist on that remote, removing stale entries that would cause fetch failures.
+let branchesToTrack =
+    let headBranch =
+        match initialState with
+        | {
+              ArgType = Url(_fullUrl, _owner, headBranch)
+              AlreadyCloned = _
+              RepoAndFolderName = _
+          } -> headBranch
+        | _ -> GetCurrentHeadBranch cloneDir
 
-        [ headBranch; branchTargetInfo.Name ]
+    let worktreeBranches = GetExistingWorktreeBranches cloneDir
 
-    let allRemoteNames =
-        AllRemotes cloneDir |> Map.toSeq |> Seq.map fst |> Seq.toList
+    (worktreeBranches @ [ headBranch; branchTargetInfo.Name ])
+    |> Seq.distinct
+    |> Seq.toList
 
-    allRemoteNames
-    |> Seq.iter(fun remoteName ->
-        for branchToFetch in branchesToFetch do
-            if CheckRemoteBranchExists cloneDir branchToFetch remoteName then
-                let setBranchesCmd =
-                    sprintf
-                        "git -C %s remote set-branches --add %s %s"
-                        cloneDir.FullPath
-                        remoteName
-                        branchToFetch
+let allRemoteNames =
+    AllRemotes cloneDir |> Map.toSeq |> Seq.map fst |> Seq.toList
 
-                Process
-                    .ExecDefault(setBranchesCmd)
-                    .UnwrapDefault(throwWhenWarnings = false)
-                |> ignore<string>
-    )
+allRemoteNames
+|> Seq.iter(fun remoteName ->
+    let existingBranches =
+        branchesToTrack
+        |> List.filter(fun branch ->
+            CheckRemoteBranchExists cloneDir branch remoteName
+        )
+
+    let setBranchesCmd =
+        let subCommand = "remote set-branches"
+        match existingBranches with
+        | [] ->
+            sprintf
+                "git -C %s %s %s"
+                cloneDir.FullPath
+                subCommand
+                remoteName
+        | branches ->
+            let branchesArg = String.Join(" ", branches)
+
+            sprintf
+                "git -C %s %s %s %s"
+                cloneDir.FullPath
+                subCommand
+                remoteName
+                branchesArg
+
+    Process
+        .ExecDefault(setBranchesCmd)
+        .UnwrapDefault(throwWhenWarnings = false)
+    |> ignore<string>
+)
 
 // Fetch all remotes
 Process

--- a/scripts/newTree.fsx
+++ b/scripts/newTree.fsx
@@ -372,6 +372,7 @@ let GetExistingWorktreeBranches(cloneDir: AbsDir) =
     |> Seq.filter(fun trimmed -> not(String.IsNullOrEmpty trimmed))
     |> Seq.choose(fun trimmed ->
         let branchPrefix = "branch refs/heads/"
+
         if trimmed.StartsWith branchPrefix then
             Some(trimmed.Substring branchPrefix.Length)
         else
@@ -698,7 +699,7 @@ allRemoteNames
         )
 
     let hasFetchRefspec =
-        try
+        match
             Process
                 .ExecDefault(
                     sprintf
@@ -707,11 +708,10 @@ allRemoteNames
                         remoteName,
                     echo = Echo.Off
                 )
-                .UnwrapDefault()
-            |> ignore
-            true
-        with
-        | _ -> false
+                .Result
+            with
+        | ProcessResultState.Error _ -> false
+        | _ -> true
 
     let maybeSetBranchesCmd =
         match existingBranches, hasFetchRefspec with


### PR DESCRIPTION
**Problem**
`newTree.fsx` crashes with `fatal: couldn't find remote ref refs/heads/someBranch` when a previously-tracked remote branch is deleted (e.g. after a PR is merged).

**Cause**
The script used `git remote set-branches --add \u003cremote\u003e \u003cbranch\u003e` once per branch. Since `--add` is cumulative, deleted branches stayed in the refspec forever and `git fetch --all` later tried (and failed) to fetch them.

**Fix**
1. Introduce `GetExistingWorktreeBranches` — inspects `git worktree list --porcelain` so we know which branches existing local worktrees depend on.
2. Build a single list of candidate branches: worktree branches + head branch + target branch.
3. For each remote, filter that list to branches that still exist (`git ls-remote`).
4. Run *one* `git remote set-branches \u003cremote\u003e \u003cbranch\u003e…` (without `--add`) per remote. This resets the refspec to exactly the branches that still exist, clearing any stale entries.

Closes #325