### PR TITLE
scripts/checkCommits1by1.fsx: fix script

### DIFF
--- a/scripts/checkCommits1by1.fsx
+++ b/scripts/checkCommits1by1.fsx
@@ -1401,6 +1401,9 @@ prCommits
             checkSuitesParsedJson.CheckSuites
             // discard check suites for the commit that are not from PR branch
             |> Seq.filter(fun suite -> suite.PullRequests.Length > 0)
+            // check suites with latest_check_runs_count=0 have also created_at=updated_at and conclusion=failure;
+            // they cause false positives, so ignore them
+            |> Seq.filter(fun suite -> suite.LatestCheckRunsCount > 0)
             // take the first one (triggered by push); second one is triggered by pull_request
             |> Seq.tryHead
 


### PR DESCRIPTION
Lately the result of Github API check suites endpoint [1] has been returning results with few first entries having latest_check_runs_count=0, status=completed, conclusion=failure, created_at=updated_at. These results caused false positives, so filtering by latest_check_runs_count was added.

[1] https://docs.github.com/en/enterprise-server@3.20/rest/checks/suites?apiVersion=2022-11-28#list-check-suites-for-a-git-reference