### PR TITLE
scripts,Test: upgrade Fsdk to latest version

### DIFF
--- a/scripts/checkCommits1by1.fsx
+++ b/scripts/checkCommits1by1.fsx
@@ -11,7 +11,7 @@ open System.Text.RegularExpressions
 #r "nuget: FSharp.Data, Version=5.0.2"
 open FSharp.Data
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 
 open Fsdk
 open Fsdk.Process

--- a/scripts/compileFSharpScripts.fsx
+++ b/scripts/compileFSharpScripts.fsx
@@ -3,7 +3,7 @@
 open System
 open System.IO
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 
 open Fsdk
 
@@ -18,7 +18,7 @@ Process
 Process
     .ExecDefault(
         sprintf
-            "dotnet tool install fsxc --version 0.9.99--date20260615-1007.git-0e932e5"
+            "dotnet tool install fsxc --version 0.9.99--date20260618-1029.git-79ec1be"
     )
     .UnwrapDefault()
 |> ignore<string>

--- a/scripts/deleteAssetsFromOldReleases.fsx
+++ b/scripts/deleteAssetsFromOldReleases.fsx
@@ -8,7 +8,7 @@ open System.Net.Http.Headers
 #r "nuget: FSharp.Data, Version=5.0.2"
 open FSharp.Data
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 
 open Fsdk
 open Fsdk.Process

--- a/scripts/deleteOldArtifacts.fsx
+++ b/scripts/deleteOldArtifacts.fsx
@@ -8,7 +8,7 @@ open System.Net.Http.Headers
 #r "nuget: FSharp.Data, Version=5.0.2"
 open FSharp.Data
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 
 open Fsdk
 open Fsdk.Process

--- a/scripts/gitPush1by1.fsx
+++ b/scripts/gitPush1by1.fsx
@@ -8,7 +8,7 @@ open System.Threading
 #r "System.Configuration"
 open System.Configuration
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 
 open Fsdk
 open Fsdk.Process

--- a/scripts/inconsistentNugetVersionsInDotNetProjects.fsx
+++ b/scripts/inconsistentNugetVersionsInDotNetProjects.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "System.Core.dll"
 #r "System.Xml.Linq.dll"
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 
 open Fsdk
 

--- a/scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
+++ b/scripts/inconsistentNugetVersionsInDotNetProjectsAndFSharpScripts.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "System.Core.dll"
 #r "System.Xml.Linq.dll"
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 #r "nuget: Microsoft.Build, Version=17.8.43"
 #r "nuget: Mono.Unix, Version=7.1.0-final.1.21458.1"
 #r "nuget: YamlDotNet, Version=16.1.3"

--- a/scripts/newTree.fsx
+++ b/scripts/newTree.fsx
@@ -9,7 +9,7 @@ open System.Text.RegularExpressions
 #r "System.Configuration"
 open System.Configuration
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 
 open Fsdk
 open Fsdk.Process

--- a/scripts/replace.fsx
+++ b/scripts/replace.fsx
@@ -6,7 +6,7 @@ open System.IO
 #r "System.Configuration"
 open System.Configuration
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 open Fsdk
 
 let errTooManyArgs =

--- a/scripts/runFSharpLint.fsx
+++ b/scripts/runFSharpLint.fsx
@@ -3,7 +3,7 @@
 open System.IO
 open System.Linq
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 
 open Fsdk
 

--- a/scripts/wrapLatestCommitMsg.fsx
+++ b/scripts/wrapLatestCommitMsg.fsx
@@ -10,7 +10,7 @@ open System.Text.RegularExpressions
 
 #load "../src/FileConventions/Library.fs"
 
-#r "nuget: Fsdk, Version=0.9.99--date20260615-1007.git-0e932e5"
+#r "nuget: Fsdk, Version=0.9.99--date20260618-1029.git-79ec1be"
 
 open Fsdk
 open Fsdk.Process

--- a/src/FileConventions.Test/FileConventions.Test.fsproj
+++ b/src/FileConventions.Test/FileConventions.Test.fsproj
@@ -19,7 +19,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
-    <PackageReference Include="Fsdk" Version="0.9.99--date20260615-1007.git-0e932e5" />
+    <PackageReference Include="Fsdk" Version="0.9.99--date20260618-1029.git-79ec1be" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Because it has workaround for `preferreduilang` argument appearing in args.
