### PR TITLE
Copy github action to separate directory

### DIFF
--- a/.github/actions/dynamic-uses/action.yml
+++ b/.github/actions/dynamic-uses/action.yml
@@ -1,0 +1,43 @@
+name: Dynamic Uses
+description: Dynamically resolve and use another GitHub action. Workaround for https://github.com/actions/runner/issues/895
+author: Jon Jensen
+inputs:
+  uses:
+    description: Action reference or path, e.g. `actions/setup-node@v3`
+    required: true
+  with:
+    description: 'JSON-ified `inputs` for the action, e.g. `{"node-version": "18"}`'
+    required: false
+    default: "{}"
+outputs:
+  outputs:
+    description: 'JSON-ified `outputs` from the action, e.g. `{"node-version": "v18.12.0", "cache-hit": true}`'
+    value: ${{ steps.run.outputs.outputs }}
+runs:
+  using: composite
+  steps:
+    - name: Setup
+      shell: bash
+      run: |
+        mkdir --parents ./.tmp-dynamic-uses &&
+        cat <<'DYNAMIC_USES_EOF' >./.tmp-dynamic-uses/action.yml
+        outputs:
+          outputs:
+            value: ${{ '$' }}{{ toJSON(steps.run.outputs) }}
+        runs:
+          using: composite
+          steps:
+          - run: rm --recursive --force ./.tmp-dynamic-uses
+            shell: bash
+          - name: Run
+            id: run
+            uses: ${{ inputs.uses }}
+            with: ${{ inputs.with || '{}' }}
+        DYNAMIC_USES_EOF
+    - name: Run
+      id: run
+      uses: ./.tmp-dynamic-uses
+    - name: Cleanup
+      if: always() && steps.run.outcome != 'success'
+      shell: bash
+      run: rm --recursive --force ./.tmp-dynamic-uses


### PR DESCRIPTION
So when referenced by external repositories, it's more clear what the action does, as reference will include path to the action.

Original action.yml at the root is not deleted to not disrupt current users. After this gets merged into master, original file can be deleted.
